### PR TITLE
chore(ci): workflow without PAT

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -13,9 +13,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete truly untagged GHCR images (dependency-safe)
-        uses: quartx-analytics/ghcr-cleaner@v1
+      - name: Clean up GHCR (delete only untagged, dependency-aware)
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          owner-type: user
-          token: ${{ secrets.GHCR_PAT }}
-          package-name: ${{ github.event.repository.name }}
+          delete-untagged: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -17,5 +17,5 @@ jobs:
         uses: quartx-analytics/ghcr-cleaner@v1
         with:
           owner-type: user
-          token: ${{ secrets.GHCR_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           package-name: ${{ github.event.repository.name }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -13,9 +13,9 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete untagged container versions
-        uses: actions/delete-package-versions@v5
+      - name: Delete truly untagged GHCR images (dependency-safe)
+        uses: quartx-analytics/ghcr-cleaner@v1
         with:
-          package-type: container
+          owner-type: user
+          token: ${{ secrets.GHCR_PAT }}
           package-name: ${{ github.event.repository.name }}
-          delete-only-untagged-versions: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -17,5 +17,5 @@ jobs:
         uses: quartx-analytics/ghcr-cleaner@v1
         with:
           owner-type: user
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GHCR_PAT }}
           package-name: ${{ github.event.repository.name }}


### PR DESCRIPTION
- Problem: “manifest unknown” occurred when the previous cleanup deleted untagged digests still referenced by multi‑arch manifests, breaking tags like `latest`.
- Change: replace the cleanup step with `dataaxiom/ghcr-cleanup-action@v1`, configured to delete only untagged digests using the default `GITHUB_TOKEN`.
- Why this action: it walks manifests and excludes child/dependent images before deletion, preventing broken tags; also avoids requiring a PAT for packages produced by this repo. Reference: https://github.com/dataaxiom/ghcr-cleanup-action
- Impact: safer cleanup; tags remain intact; no secret management needed.
- Ops note: if `latest` is already broken, re-run the Docker build/manifest merge once to restore.