### PR TITLE
feat(cli)!: unify report CLI via from-clickhouse subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [0.1.0-rc.2]
 
 ### Changed
-- CLI: `report` now uses a subcommand: `rdbinsight report from-clickhouse --url <URL> [--proxy-url <PROXY>] --cluster <CLUSTER> [--batch <RFC3339>] [-o <OUTPUT>]`. This replaces passing ClickHouse parameters directly on `report`.
+- CLI: Unified argument style across subcommands. `report` now uses `from-clickhouse` instead of direct ClickHouse flags. Example: `rdbinsight report from-clickhouse --url <URL> [--proxy-url <PROXY>]`.
 
 ## [0.1.0-rc.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.1.0-rc.2]
+
+### Changed
+- CLI: `report` now uses a subcommand: `rdbinsight report from-clickhouse --url <URL> [--proxy-url <PROXY>] --cluster <CLUSTER> [--batch <RFC3339>] [-o <OUTPUT>]`. This replaces passing ClickHouse parameters directly on `report`.
+
 ## [0.1.0-rc.1]
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "rdbinsight"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdbinsight"
-version = "0.1.0-rc.1"
+version = "0.1.0-rc.2"
 edition = "2024"
 description = "A command-line tool for parsing and analyzing Redis RDB."
 


### PR DESCRIPTION
### Description
- Introduce `rdbinsight report from-clickhouse` to replace direct ClickHouse flags on `report`.
- Unifies argument style across subcommands (aligned with `dump ... into-clickhouse`).
- Bump version to 0.1.0-rc.2 and update CHANGELOG.

### Migration
- Before:
```bash
rdbinsight report \
  --cluster your_cluster \
  --batch 2024-01-01T00:00:00Z \
  --output report.html \
  --clickhouse-url http://127.0.0.1:8123/rdbinsight \
  --clickhouse-proxy-url http://127.0.0.1:7890
```

- After:
```bash
rdbinsight report from-clickhouse \
  --cluster your_cluster \
  --batch 2024-01-01T00:00:00Z \
  -o report.html \
  --url http://127.0.0.1:8123/rdbinsight \
  --proxy-url http://127.0.0.1:7890
```

### BREAKING CHANGE
- Direct ClickHouse flags on `report` are removed; use `report from-clickhouse` instead.