### PR TITLE
feat(clickhouse): require explicit port and ?database=; simplify client config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [0.1.0-rc.3]
 ### Breaking
-- Require `http[s]://host:port?database=<db>` for ClickHouse (path database removed)
+- Require `http[s]://host:port?database=<db>` for ClickHouse to align with the [official HTTP interface](https://clickhouse.com/docs/interfaces/http) and avoid issues in complex deployments (e.g., multi-layer reverse proxies); path-based database selection is removed
 
 ### Features
 - Add sanitized info logs for ClickHouse/Proxy URLs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [Unreleased]
 
-## [0.1.0-rc.3]
 ### Breaking
 - Require `http[s]://host:port?database=<db>` for ClickHouse to align with the [official HTTP interface](https://clickhouse.com/docs/interfaces/http) and avoid issues in complex deployments (e.g., multi-layer reverse proxies); path-based database selection is removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.1.0-rc.3]
+### Breaking
+- Require `http[s]://host:port?database=<db>` for ClickHouse (path database removed)
+
+### Features
+- Add sanitized info logs for ClickHouse/Proxy URLs
+
 ## [0.1.0-rc.2]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd798aea3553913a5986813e9c6ad31a2d2b04e931fe8ea4a37155eb541cebb5"
+checksum = "c26b57282a08ae92f727497805122fec964c6245cfa0e13f0e75452eaf3bc41f"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508dafb53e5804a238cab7fd97a59ddcbfab20cc4d9814b1ab5465b9fa147f2e"
+checksum = "cebf38ca279120ff522f4954b81a39527425b6e9f615e6b72842f4de1ffe02b8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2730bc045d62bb2e53ef8395b7d4242f5c8102f41ceac15e8395b9ac3d08461"
+checksum = "744109142cdf8e7b02795e240e20756c2a782ac9180d4992802954a8f871c0de"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54295b93beb702ee9a6f6fbced08ad7f4d76ec1c297952d4b83cf68755421d1d"
+checksum = "601bb103c4c374bcd1f62c66bcea67b42a2ee91a690486c37d4c180236f11ccc"
 dependencies = [
  "bytes",
  "half",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e8bcb7dc971d779a7280593a1bf0c2743533b8028909073e804552e85e75b5"
+checksum = "eed61d9d73eda8df9e3014843def37af3050b5080a9acbe108f045a316d5a0be"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673fd2b5fb57a1754fdbfac425efd7cf54c947ac9950c1cce86b14e248f1c458"
+checksum = "fa95b96ce0c06b4d33ac958370db8c0d31e88e54f9d6e08b0353d18374d9f991"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c22fe3da840039c69e9f61f81e78092ea36d57037b4900151f063615a2f6b4"
+checksum = "43407f2c6ba2367f64d85d4603d6fb9c4b92ed79d2ffd21021b37efa96523e12"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -243,22 +243,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778de14c5a69aedb27359e3dd06dd5f9c481d5f6ee9fbae912dba332fd64636b"
+checksum = "e4b0487c4d2ad121cbc42c4db204f1509f8618e589bc77e635e9c40b502e3b90"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
+ "arrow-select",
  "flatbuffers",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3860db334fe7b19fcf81f6b56f8d9d95053f3839ffe443d56b5436f7a29a1794"
+checksum = "26d747573390905905a2dc4c5a61a96163fe2750457f90a04ee2a88680758c79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -267,7 +268,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "lexical-core",
  "memchr",
  "num",
@@ -278,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425fa0b42a39d3ff55160832e7c25553e7f012c3f187def3d70313e7a29ba5d9"
+checksum = "c142a147dceb59d057bad82400f1693847c80dca870d008bf7b91caf902810ae"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -291,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9c9423c9e71abd1b08a7f788fcd203ba2698ac8e72a1f236f1faa1a06a7414"
+checksum = "dac6620667fccdab4204689ca173bd84a15de6bb6b756c3a8764d4d7d0c2fc04"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -304,15 +305,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fa1babc4a45fdc64a92175ef51ff00eba5ebbc0007962fecf8022ac1c6ce28"
+checksum = "dfa93af9ff2bb80de539e6eb2c1c8764abd0f4b73ffb0d7c82bf1f9868785e66"
 
 [[package]]
 name = "arrow-select"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8854d15f1cf5005b4b358abeb60adea17091ff5bdd094dca5d3f73787d81170"
+checksum = "be8b2e0052cd20d36d64f32640b68a5ab54d805d24a473baee5d52017c85536c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -324,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c477e8b89e1213d5927a2a84a72c384a9bf4dd0dbf15f9fd66d821aafd9e95e"
+checksum = "c2155e26e17f053c8975c546fc70cf19c00542f9abf43c23a88a46ef7204204f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -336,7 +337,7 @@ dependencies = [
  "memchr",
  "num",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -506,9 +507,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bollard"
@@ -518,7 +519,7 @@ checksum = "899ca34eb6924d6ec2a77c6f7f5c7339e60fd68235eaf91edd5a15f12958bb06"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -649,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.33"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",
@@ -741,7 +742,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 [[package]]
 name = "clickhouse"
 version = "0.13.3"
-source = "git+https://github.com/ClickHouse/clickhouse-rs.git#61c8159464df80b53717b69a0738ebc9d19732bd"
+source = "git+https://github.com/ClickHouse/clickhouse-rs.git#44525e40cf925fb0344e31b97c520ed288cd1991"
 dependencies = [
  "bstr",
  "bytes",
@@ -767,7 +768,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-derive"
 version = "0.2.0"
-source = "git+https://github.com/ClickHouse/clickhouse-rs.git#61c8159464df80b53717b69a0738ebc9d19732bd"
+source = "git+https://github.com/ClickHouse/clickhouse-rs.git#44525e40cf925fb0344e31b97c520ed288cd1991"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -778,7 +779,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-types"
 version = "0.1.0"
-source = "git+https://github.com/ClickHouse/clickhouse-rs.git#61c8159464df80b53717b69a0738ebc9d19732bd"
+source = "git+https://github.com/ClickHouse/clickhouse-rs.git#44525e40cf925fb0344e31b97c520ed288cd1991"
 dependencies = [
  "bytes",
  "thiserror 1.0.69",
@@ -1170,7 +1171,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "rustc_version",
 ]
 
@@ -1357,7 +1358,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
  "libgit2-sys",
  "log",
@@ -1376,7 +1377,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1813,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1839,11 +1840,11 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -1905,9 +1906,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -2023,7 +2024,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
  "redox_syscall 0.5.17",
 ]
@@ -2378,7 +2379,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2465,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "56.0.0"
+version = "56.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7288a07ed5d25939a90f9cb1ca5afa6855faa08ec7700613511ae64bdb0620c"
+checksum = "89b56b41d1bd36aae415e42f91cae70ee75cf6cba74416b14dce3e958d5990ec"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2506,7 +2507,7 @@ checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
 dependencies = [
  "parse-display-derive",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -2518,7 +2519,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
  "structmeta",
  "syn",
 ]
@@ -2662,7 +2663,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "hex",
  "procfs-core",
  "rustix 0.38.44",
@@ -2674,7 +2675,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "hex",
 ]
 
@@ -2981,7 +2982,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -3006,14 +3007,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -3027,13 +3028,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -3044,9 +3045,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "replace_with"
@@ -3154,7 +3155,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3167,7 +3168,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3305,7 +3306,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3318,7 +3319,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3442,7 +3443,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -3664,7 +3665,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3959,7 +3960,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -3970,9 +3971,9 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "toml_datetime",
- "winnow 0.7.12",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -4012,7 +4013,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4029,7 +4030,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytes",
  "futures-util",
  "http",
@@ -4225,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4792,9 +4793,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -4815,7 +4816,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "rdbinsight"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "rdbinsight"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.2"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdbinsight"
-version = "0.1.0-rc.2"
+version = "0.1.0-rc.3"
 edition = "2024"
 description = "A command-line tool for parsing and analyzing Redis RDB."
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tracing-subscriber = { version = "0.3.19", features = [
     "env-filter",
 ] }
 typed-builder = "0.21.2"
-url = "2.5.6"
+url = { version = "2.5.6", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdbinsight"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.2"
 edition = "2024"
 description = "A command-line tool for parsing and analyzing Redis RDB."
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,10 @@ tracing-subscriber = { version = "0.3.19", features = [
 typed-builder = "0.21.2"
 url = { version = "2.5.6", features = ["serde"] }
 
+[build-dependencies]
+shadow-rs = "1.2.1"
+
 [dev-dependencies]
 tempfile = "3.20.0"
 testcontainers = { version = "0.25.0", features = ["http_wait"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-
-[build-dependencies]
-shadow-rs = "1.2.1"

--- a/justfile
+++ b/justfile
@@ -47,4 +47,4 @@ down_dev:
 demo with_data='true': up_dev
     if {{with_data}} == 'true'; then cargo run --release --bin fill_redis_memory -- 'redis://127.0.0.1:6380' '512M'; fi
     cargo run --release --bin rdbinsight -- dump from-standalone --addr '127.0.0.1:6380' --cluster 'dev-test-cluster' into-clickhouse --url 'http://rdbinsight:rdbinsight@127.0.0.1:8124?database=rdbinsight' --auto-create-tables
-    cargo run --release --bin rdbinsight -- report --cluster 'dev-test-cluster' --clickhouse-url 'http://rdbinsight:rdbinsight@127.0.0.1:8124?database=rdbinsight'
+    cargo run --release --bin rdbinsight -- report from-clickhouse --cluster 'dev-test-cluster' --url 'http://rdbinsight:rdbinsight@127.0.0.1:8124?database=rdbinsight'

--- a/justfile
+++ b/justfile
@@ -46,5 +46,5 @@ down_dev:
 
 demo with_data='true': up_dev
     if {{with_data}} == 'true'; then cargo run --release --bin fill_redis_memory -- 'redis://127.0.0.1:6380' '512M'; fi
-    cargo run --release --bin rdbinsight -- dump from-standalone --addr '127.0.0.1:6380' --cluster 'dev-test-cluster' into-clickhouse --url 'http://rdbinsight:rdbinsight@127.0.0.1:8124' --auto-create-tables
-    cargo run --release --bin rdbinsight -- report --cluster 'dev-test-cluster' --clickhouse-url 'http://rdbinsight:rdbinsight@127.0.0.1:8124'
+    cargo run --release --bin rdbinsight -- dump from-standalone --addr '127.0.0.1:6380' --cluster 'dev-test-cluster' into-clickhouse --url 'http://rdbinsight:rdbinsight@127.0.0.1:8124?database=rdbinsight' --auto-create-tables
+    cargo run --release --bin rdbinsight -- report --cluster 'dev-test-cluster' --clickhouse-url 'http://rdbinsight:rdbinsight@127.0.0.1:8124?database=rdbinsight'

--- a/src/bin/rdbinsight.rs
+++ b/src/bin/rdbinsight.rs
@@ -197,11 +197,8 @@ enum OutputCommand {
 
 #[derive(Parser)]
 struct ClickHouseOutputArgs {
-    /// ClickHouse server URL (http[s]://[username[:password]@]host[:port]/[database])
-    ///
-    /// Default port: 8123
-    ///
-    /// Default database: rdbinsight
+    /// ClickHouse server URL (must include explicit port and ?database=<db>)
+    /// Example: http[s]://[user[:pass]@]host:8123?database=<db>
     #[arg(long, env = "RDBINSIGHT_CLICKHOUSE_URL")]
     url: Url,
 
@@ -253,11 +250,8 @@ struct ReportFromClickHouseArgs {
     #[clap(short, long, env = "RDBINSIGHT_REPORT_OUTPUT")]
     output: Option<PathBuf>,
 
-    /// ClickHouse server URL (http[s]://[username[:password]@]host[:port]/[database])
-    ///
-    /// Default port: 8123
-    ///
-    /// Default database: rdbinsight
+    /// ClickHouse server URL (must include explicit port and ?database=<db>)
+    /// Example: http[s]://[user[:pass]@]host:8123?database=<db>
     #[arg(long, env = "RDBINSIGHT_CLICKHOUSE_URL")]
     url: Url,
 
@@ -730,10 +724,6 @@ async fn run_report(args: ReportArgs) -> Result<()> {
                 false, // Reports don't need auto-creation
                 sub.proxy_url,
             )?;
-
-            clickhouse_config
-                .validate()
-                .with_context(|| "Invalid ClickHouse configuration")?;
 
             rdbinsight::report::run_report_with_config(
                 clickhouse_config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -436,7 +436,7 @@ impl ClickHouseConfig {
             .pool_idle_timeout(Duration::from_secs(90))
             .build(proxy_connector);
 
-        let mut client = Client::with_http_client(http_client).with_url(&self.url.to_string());
+        let mut client = Client::with_http_client(http_client).with_url(self.url.to_string());
 
         if !self.url.username().is_empty() {
             client = client.with_user(self.url.username());

--- a/src/config.rs
+++ b/src/config.rs
@@ -448,5 +448,3 @@ impl ClickHouseConfig {
         Ok(client)
     }
 }
-
-// removed: default_database (database must be provided in URL)

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -224,6 +224,7 @@ async fn run_clickhouse_test(test_case: &TestCase) -> AnyResult {
 
 #[tokio::test]
 async fn test_clickhouse_connections() {
+    // TODO: add testcase to clickhouse with authentication
     let test_cases = [
         TestCase {
             name: "Direct connection",

--- a/tests/clickhouse_test.rs
+++ b/tests/clickhouse_test.rs
@@ -202,8 +202,9 @@ async fn run_clickhouse_test(test_case: &TestCase) -> AnyResult {
         println!("Proxy URL: {}", proxy);
     }
 
+    let url_with_db = format!("{}?database=rdbinsight", clickhouse_url);
     let client = rdbinsight::config::ClickHouseConfig::new(
-        Url::parse(clickhouse_url).unwrap(),
+        Url::parse(&url_with_db).unwrap(),
         false,
         proxy_url,
     )?

--- a/tests/common/clickhouse.rs
+++ b/tests/common/clickhouse.rs
@@ -46,8 +46,8 @@ pub async fn start_clickhouse(network_name: Option<&str>) -> Result<ClickHouseIn
         .await
         .context("Failed to get ClickHouse container bridge IP address")?;
 
-    let internal_url = format!("http://{internal_ip}:{CLICKHOUSE_PORT}");
-    let host_url = format!("http://127.0.0.1:{host_port}");
+    let internal_url = format!("http://{internal_ip}:{CLICKHOUSE_PORT}?database=rdbinsight");
+    let host_url = format!("http://127.0.0.1:{host_port}?database=rdbinsight");
 
     Ok(ClickHouseInstance {
         container,

--- a/tests/common/clickhouse.rs
+++ b/tests/common/clickhouse.rs
@@ -46,8 +46,8 @@ pub async fn start_clickhouse(network_name: Option<&str>) -> Result<ClickHouseIn
         .await
         .context("Failed to get ClickHouse container bridge IP address")?;
 
-    let internal_url = format!("http://{internal_ip}:{CLICKHOUSE_PORT}?database=rdbinsight");
-    let host_url = format!("http://127.0.0.1:{host_port}?database=rdbinsight");
+    let internal_url = format!("http://{internal_ip}:{CLICKHOUSE_PORT}");
+    let host_url = format!("http://127.0.0.1:{host_port}");
 
     Ok(ClickHouseInstance {
         container,

--- a/tests/report_test.rs
+++ b/tests/report_test.rs
@@ -58,7 +58,10 @@ async fn test_report_generate_data_with_clickhouse() {
     info!("ClickHouse container started: {}", env.host_url);
 
     // 2) build clickhouse config and output (auto-create tables)
-    let ch_url = Url::parse(&env.host_url).unwrap();
+    let mut ch_url = Url::parse(&env.host_url).unwrap();
+    ch_url
+        .query_pairs_mut()
+        .append_pair("database", "rdbinsight");
     let ch_config = ClickHouseConfig::new(ch_url, true, None).unwrap();
     let cluster = "test-cluster".to_string();
     let batch_ts = OffsetDateTime::now_utc();
@@ -140,7 +143,10 @@ async fn test_report_generate_data_with_empty_cluster() {
     info!("ClickHouse container started: {}", env.host_url);
 
     // 2) build clickhouse config and output (auto-create tables)
-    let ch_url = Url::parse(&env.host_url).unwrap();
+    let mut ch_url = Url::parse(&env.host_url).unwrap();
+    ch_url
+        .query_pairs_mut()
+        .append_pair("database", "rdbinsight");
     let ch_config = ClickHouseConfig::new(ch_url, true, None).unwrap();
     let cluster = "empty-cluster".to_string();
     let batch_ts = OffsetDateTime::now_utc();


### PR DESCRIPTION
### Breaking
- ClickHouse URL must include explicit port and database via `?database=`. Path-based DB segments are removed.

### Changed
- Refactor `ClickHouseConfig` to keep only the full URL; validate in `new()`.
- Use ClickHouse SDK to read `username`/`password`/`database` from URL; stop manual overrides.
- Update CLI help to require `http[s]://host:port?database=<db>` (no defaults).
- Add sanitized info logs for ClickHouse and proxy URLs on config creation.