### PR TITLE
fix(report): deduplicate top prefixes in ParquetReportProvider and enforce invariants

### DIFF
--- a/src/report/model.rs
+++ b/src/report/model.rs
@@ -42,7 +42,7 @@ pub struct InstanceAggregate {
 }
 
 #[serde_as]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Eq, PartialEq)]
 pub struct PrefixAggregate {
     #[serde_as(as = "Base64")]
     #[serde(rename = "prefix_base64")]

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -247,7 +247,13 @@ impl ParquetReportProvider {
 }
 
 fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate>) {
+    if agg.len() < 2 {
+        out.extend_from_slice(&agg);
+        return;
+    }
+
     agg.sort_by(|x, y| x.prefix.cmp(&y.prefix));
+
     for (cur, nxt) in agg.iter().tuple_windows() {
         if cur.key_count == nxt.key_count {
             continue;

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -263,7 +263,7 @@ fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate
             "key_count invariant violated"
         );
         assert!(
-            cur.total_size >= nxt.total_size,
+            cur.total_size <= nxt.total_size,
             "total_size invariant violated"
         );
         assert!(

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -260,20 +260,29 @@ fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate
         // some checks to ensure the invariant is met
         assert!(
             cur.prefix.len() < nxt.prefix.len(),
-            "prefix length invariant violated"
+            "unexpected error found: prefix length invariant violated"
         );
         assert!(
             nxt.prefix.starts_with(&cur.prefix),
-            "prefix order invariant violated"
+            "unexpected error found: prefix order invariant violated"
         );
 
         if cur.key_count == nxt.key_count {
-            assert_eq!(cur.total_size, nxt.total_size, "total_size should be equal when key_count is equal");
+            assert_eq!(
+                cur.total_size, nxt.total_size,
+                "unexpected error found: total_size should be equal when key_count is equal"
+            );
             continue;
         }
 
-        assert!(cur.key_count > nxt.key_count, "key_count should be greater when total_size is greater");
-        assert!(cur.total_size > nxt.total_size, "total_size should be greater when key_count is greater");
+        assert!(
+            cur.key_count > nxt.key_count,
+            "unexpected error found: key_count should be greater when total_size is greater"
+        );
+        assert!(
+            cur.total_size > nxt.total_size,
+            "unexpected error found: total_size should be greater when key_count is greater"
+        );
         out.push(cur.clone());
     }
     // last one is the longest prefix, always should be pushed

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -289,7 +289,7 @@ impl DBElementsIterator {
             .as_binary::<i32>();
         let size_array = batch
             .column_by_name("rdb_size")
-            .ok_or_else(|| anyhow!("can't find field 'size' in parquet file"))?
+            .ok_or_else(|| anyhow!("can't find field 'rdb_size' in parquet file"))?
             .as_primitive::<UInt64Type>();
         for i in 0..key_array.len() {
             let key = key_array.value(i);

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -259,14 +259,6 @@ fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate
     for (cur, nxt) in agg.iter().tuple_windows() {
         // some checks to ensure the invariant is met
         assert!(
-            cur.key_count <= nxt.key_count,
-            "key_count invariant violated"
-        );
-        assert!(
-            cur.total_size <= nxt.total_size,
-            "total_size invariant violated"
-        );
-        assert!(
             cur.prefix.len() < nxt.prefix.len(),
             "prefix length invariant violated"
         );
@@ -276,8 +268,12 @@ fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate
         );
 
         if cur.key_count == nxt.key_count {
+            assert_eq!(cur.total_size, nxt.total_size, "total_size should be equal when key_count is equal");
             continue;
         }
+
+        assert!(cur.key_count > nxt.key_count, "key_count should be greater when total_size is greater");
+        assert!(cur.total_size > nxt.total_size, "total_size should be greater when key_count is greater");
         out.push(cur.clone());
     }
     // last one is the longest prefix, always should be pushed


### PR DESCRIPTION
### Summary
- Remove duplicate prefix aggregates in parquet-backed reports.
- Enforce invariants for per-key prefix-chain batches.

### Changes
- Add deduplicate_push with invariant checks (panic on violation).
- Replace final `sort_by_key(|x| x.prefix.clone())` with comparator to avoid `Bytes` clone.
- Align error message with actual column name: `rdb_size`.
- Derive `Eq, PartialEq` for `PrefixAggregate`.

### Rationale
- Ensure each parent/child chain keeps only the most specific prefix when counts match.
- Surface logic regressions early via explicit invariant checks.

### Behavior
- Output `top_prefixes` remains lexicographically sorted by raw bytes.
- No change to thresholds or aggregation rules.

### Risk & Compatibility
- Panics will occur if invariants are broken; intended to catch unexpected data/logic.
- Otherwise backward compatible.

### Notes
- Invariants assumed per batch:
  - Unique prefixes.
  - Strict prefix-chain ordering (comparable by starts_with).
  - `key_count` equality implies `total_size` equality; differences imply both differ.