### PR TITLE
feat(time): enable large-dates for TTL; update deps and harden expire_at conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0-rc.7]
 
-### Changed
+### Added
 - Enable `time` crate `large-dates` feature to support very large TTL values.
 
 ## [0.1.0-rc.6]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.7]
+
+### Changed
+- Enable `time` crate `large-dates` feature to support very large TTL values.
+
 ## [0.1.0-rc.6]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "flatbuffers"
@@ -1369,7 +1369,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.4+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -3250,7 +3250,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.3.0",
+ "security-framework 3.4.0",
 ]
 
 [[package]]
@@ -3366,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
 dependencies = [
  "bitflags 2.9.4",
  "core-foundation 0.10.1",
@@ -3379,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4356,9 +4356,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4875,9 +4875,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"
@@ -4921,18 +4921,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "rdbinsight"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_with = { version = "3.11.0", features = ["base64"] }
 shadow-rs = "1.2.1"
 spire_enum = "0.6.0"
 thiserror = "2.0.12"
-time = { version = "0.3.41", features = ["formatting", "parsing", "macros"] }
+time = { version = "0.3.41", features = ["formatting", "parsing", "macros", "large-dates"] }
 tokio = { version = "1.45.1", features = ["full"] }
 tokio-util = { version = "0.7.15", features = ["time"] }
 tower-service = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdbinsight"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 edition = "2024"
 description = "A command-line tool for parsing and analyzing Redis RDB."
 

--- a/src/output/clickhouse.rs
+++ b/src/output/clickhouse.rs
@@ -271,12 +271,13 @@ impl crate::output::ChunkWriter for ClickHouseChunkWriter {
             encoding: record.encoding_name(),
             expire_at: record.expire_at_ms.map(|ms| {
                 OffsetDateTime::from_unix_timestamp_nanos((ms as i128) * 1_000_000).unwrap_or_else(
-                    |_| {
+                    |err| {
                         panic!(
-                            "failed to convert expire_at_ms to OffsetDateTime, value is {}",
-                            ms
+                            "failed to convert expire_at_ms to OffsetDateTime, value is {}, error: {}",
+                            ms,
+                            err
                         )
-                    },
+                    }
                 )
             }),
             idle_seconds: record.idle_seconds,

--- a/src/output/clickhouse.rs
+++ b/src/output/clickhouse.rs
@@ -270,8 +270,14 @@ impl crate::output::ChunkWriter for ClickHouseChunkWriter {
             rdb_size: record.rdb_size,
             encoding: record.encoding_name(),
             expire_at: record.expire_at_ms.map(|ms| {
-                OffsetDateTime::from_unix_timestamp_nanos((ms as i128) * 1_000_000)
-                    .expect("Failed to convert milliseconds to nanoseconds")
+                OffsetDateTime::from_unix_timestamp_nanos((ms as i128) * 1_000_000).unwrap_or_else(
+                    |_| {
+                        panic!(
+                            "failed to convert expire_at_ms to OffsetDateTime, value is {}",
+                            ms
+                        )
+                    },
+                )
             }),
             idle_seconds: record.idle_seconds,
             freq: record.freq,

--- a/src/parser/state/combinators/seq.rs
+++ b/src/parser/state/combinators/seq.rs
@@ -7,19 +7,12 @@ use crate::{
 };
 
 /// Internal state machine wrapper used by `seq_parser!` macro.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum ParserPhase<P: StateParser> {
+    #[default]
     Init,
     Call(P),
     Done(P::Output),
-}
-
-impl<P> Default for ParserPhase<P>
-where P: StateParser
-{
-    fn default() -> Self {
-        Self::Init
-    }
 }
 
 impl<P> ParserPhase<P>


### PR DESCRIPTION
- Enable `time` crate `large-dates` feature in `Cargo.toml` to support very large TTL values.
- Bump package version to `0.1.0-rc.7` and update `Cargo.lock` with dependency version updates.
- Harden conversion of `expire_at_ms` in `src/output/clickhouse.rs` with clearer panic message on failure.