### PR TITLE
feat(report): add human-readable byte-size formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Display-only: human-friendly byte-size formatting for reports and progress logs.
+
 ## [0.1.0-rc.7]
 
 ### Added
+
 - Enable `time` crate `large-dates` feature to support very large TTL values.
 
 ## [0.1.0-rc.6]
 
 ### Added
+
 - Report: add periodic progress logs when scanning Parquet files' keys to avoid long silence during report generation.
 - Report: log newly discovered significant prefixes during top-prefix discovery to surface important findings early.
 
 ### Changed
+
 - Report (Parquet): switch top-prefix discovery to a single-pass LCP stack algorithm, significantly reducing CPU and speeding up report generation.
 
 ## [0.1.0-rc.5]
 
 ### Fixed
+
 - Parser: support LZF-encoded RDB strings and fix incorrect handling of LZF-compressed IntSet strings in RDB files (now correctly unboxes compressed strings and reads intset header).
 
 ## [0.1.0-rc.4]
 
 ### Changed
+
 - BREAKING: Parquet adopts Hadoop-style layout with batch-level atomic finalize: `_tmp_batch=<batch>` → `batch=<batch>`.
 
 ### Added
+
 - Parquet: Per-instance external merge sort; one final file per instance sorted by `(db, key)`.
 - Parquet: Configurable compression for runs (LZ4) and final files (ZSTD).
 - Use `mimalloc` as the global allocator to improve memory management and performance
@@ -40,19 +50,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0-rc.3]
 
 ### Changed
+
 - BREAKING: Require `http[s]://host:port?database=<db>` for ClickHouse to align with the [official HTTP interface](https://clickhouse.com/docs/interfaces/http) and avoid issues in complex deployments (e.g., multi-layer reverse proxies); path-based database selection is removed
 
 ### Added
+
 - Add sanitized info logs for ClickHouse/Proxy URLs
 
 ## [0.1.0-rc.2]
 
 ### Changed
+
 - CLI: Unified argument style across subcommands. `report` now uses `from-clickhouse` instead of direct ClickHouse flags. Example: `rdbinsight report from-clickhouse --url <URL> [--proxy-url <PROXY>]`.
 
 ## [0.1.0-rc.1]
 
 ### Added
+
 - Multiple Data Sources Support: Support for dumping data from Redis standalone instances, Redis clusters, Codis clusters, and local RDB files
 - Multiple Output Targets: Support for outputting parsed data to ClickHouse database and local Parquet files
 - HTML Report Generation: Capability to generate self-contained HTML reports from ClickHouse tables

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -309,7 +309,7 @@ impl ParquetReportProvider {
 fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate>) {
     if agg.len() < 2 {
         for a in &agg {
-            let total_size_fmt = crate::helper::format_number(a.total_size as f64);
+            let total_size_fmt = crate::helper::format_bytesize(a.total_size);
             tracing::info!(
                 operation = "significant_prefix_discovered",
                 prefix = %String::from_utf8_lossy(&a.prefix),
@@ -352,7 +352,7 @@ fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate
             "unexpected error found: total_size should be greater when key_count is greater"
         );
         {
-            let total_size_fmt = crate::helper::format_number(cur.total_size as f64);
+            let total_size_fmt = crate::helper::format_bytesize(cur.total_size);
             tracing::info!(
                 operation = "significant_prefix_discovered",
                 prefix = %String::from_utf8_lossy(&cur.prefix),
@@ -365,7 +365,7 @@ fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate
     }
     // last one is the longest prefix, always should be pushed
     if let Some(last) = agg.last() {
-        let total_size_fmt = crate::helper::format_number(last.total_size as f64);
+        let total_size_fmt = crate::helper::format_bytesize(last.total_size);
         tracing::info!(
             operation = "significant_prefix_discovered",
             prefix = %String::from_utf8_lossy(&last.prefix),


### PR DESCRIPTION
- Add `format_bytesize(bytes: u64)` utility to `src/helper.rs` (1024 base, units: B/KB/MB/GB/TB/PB).
- Use `format_bytesize` for report/log size displays (replace size-specific `format_number` calls) in `src/report/parquet.rs`.
- Add unit tests covering byte-size formatting.
- Display-only change: no behavioral or data-model changes.