### PR TITLE
fix(clickhouse): handle overflow in expire_at_ms conversion and log saturation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0-rc.8]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Display-only: human-friendly byte-size formatting for reports and progress logs.
+- ClickHouse Output: saturate overflow `expire_at_ms` to a maximum datetime instead of panicking during conversion.
 
 ## [0.1.0-rc.7]
 
-### Added
+### Changed
 
 - Enable `time` crate `large-dates` feature to support very large TTL values.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "rdbinsight"
-version = "0.1.0-rc.7"
+version = "0.1.0-rc.8"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdbinsight"
-version = "0.1.0-rc.7"
+version = "0.1.0-rc.8"
 edition = "2024"
 description = "A command-line tool for parsing and analyzing Redis RDB."
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -5,6 +5,9 @@ pub mod sort_merge;
 
 use crc::{CRC_16_XMODEM, CRC_32_ISO_HDLC, Crc};
 pub use sort_merge::SortMergeIterator;
+use time::{Date, OffsetDateTime, Time};
+
+pub const MAX_DATETIME: OffsetDateTime = OffsetDateTime::new_utc(Date::MAX, Time::MAX);
 
 pub fn wrapping_to_usize(value: u64) -> usize {
     value.try_into().unwrap_or(usize::MAX)


### PR DESCRIPTION
- Update ClickHouse output to saturate overflow `expire_at_ms` to a maximum datetime instead of panicking during conversion.
- Introduce `MAX_DATETIME` constant for maximum supported datetime.
- Log a warning when `expire_at_ms` exceeds the supported range, indicating saturation to `MAX_DATETIME`.
- Update CHANGELOG to reflect changes in behavior for ClickHouse output.