### PR TITLE
feat(report): surface parquet scan throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Report (Parquet): progress logs now include average rows-per-second throughput when scanning top prefixes.
+
 ## [0.1.0-rc.8]
 
 ### Changed

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -4,6 +4,7 @@ use std::{
     fs,
     ops::AddAssign,
     path::{Path, PathBuf},
+    time::Instant,
 };
 
 use anyhow::{Context, Result, anyhow, bail, ensure};
@@ -211,6 +212,7 @@ impl ParquetReportProvider {
 
         let threshold = (total_size / 100).max(1);
         let mut processed: u64 = 0;
+        let start = Instant::now();
 
         let iter = self.build_group_merge_iterator()?;
 
@@ -268,9 +270,16 @@ impl ParquetReportProvider {
             processed = processed.saturating_add(1);
             if processed.is_multiple_of(PROGRESS_INTERVAL) {
                 let processed_fmt = crate::helper::format_number(processed as f64);
+                let elapsed_secs = start.elapsed().as_secs_f64();
+                let rows_per_second_fmt = if elapsed_secs > 0.0 {
+                    crate::helper::format_number(processed as f64 / elapsed_secs)
+                } else {
+                    "inf".to_string()
+                };
                 tracing::info!(
                     operation = "scan_top_prefix_progress",
                     processed = %processed_fmt,
+                    rows_per_second = %rows_per_second_fmt,
                     total_size = total_size,
                     "Report scanning progress"
                 );

--- a/src/report/parquet.rs
+++ b/src/report/parquet.rs
@@ -235,14 +235,11 @@ impl ParquetReportProvider {
             i
         }
 
-        let mut scratch: Vec<PrefixAggregate> = Vec::new();
-
         // Helper: pop nodes deeper than target depth, bubble up totals to parent,
-        // and emit significant prefixes using the existing deduplicate logic while
-        // reusing a scratch buffer to avoid repeated allocations.
-        let mut pop_to_depth =
+        // and emit significant prefixes using the existing deduplicate_push logic.
+        let pop_to_depth =
             |target_depth: usize, stack: &mut Vec<Node>, out: &mut Vec<PrefixAggregate>| {
-                scratch.clear();
+                let mut agg_candidates: Vec<PrefixAggregate> = Vec::new();
                 while stack.len() > target_depth {
                     let node = stack.pop().expect("stack not empty when popping");
                     // Bubble up to parent so ancestors receive full subtree totals
@@ -251,16 +248,15 @@ impl ParquetReportProvider {
                         parent.key_count = parent.key_count.saturating_add(node.key_count);
                     }
                     if node.total_size >= threshold {
-                        scratch.push(PrefixAggregate {
+                        agg_candidates.push(PrefixAggregate {
                             prefix: node.prefix,
                             total_size: node.total_size,
                             key_count: node.key_count,
                         });
                     }
                 }
-                if !scratch.is_empty() {
-                    deduplicate_push(&scratch, out);
-                    scratch.clear();
+                if !agg_candidates.is_empty() {
+                    deduplicate_push(agg_candidates, out);
                 }
             };
 
@@ -319,62 +315,75 @@ impl ParquetReportProvider {
     }
 }
 
-fn deduplicate_push(agg: &[PrefixAggregate], out: &mut Vec<PrefixAggregate>) {
-    if agg.is_empty() {
+fn deduplicate_push(mut agg: Vec<PrefixAggregate>, out: &mut Vec<PrefixAggregate>) {
+    if agg.len() < 2 {
+        for a in &agg {
+            let total_size_fmt = crate::helper::format_bytesize(a.total_size);
+            tracing::info!(
+                operation = "significant_prefix_discovered",
+                prefix = %String::from_utf8_lossy(&a.prefix),
+                total_size = %total_size_fmt,
+                key_count = a.key_count,
+                "Discovered new significant prefix"
+            );
+        }
+        out.extend_from_slice(&agg);
         return;
     }
 
-    // Aggregates are provided deepest-first; iterate shallow -> deep to keep lexicographic order
-    for idx in (1..agg.len()).rev() {
-        let child = &agg[idx];
-        let parent = &agg[idx - 1];
+    agg.sort_by(|x, y| x.prefix.cmp(&y.prefix));
+
+    for (cur, nxt) in agg.iter().tuple_windows() {
+        // some checks to ensure the invariant is met
         assert!(
-            child.prefix.len() < parent.prefix.len(),
+            cur.prefix.len() < nxt.prefix.len(),
             "unexpected error found: prefix length invariant violated"
         );
         assert!(
-            parent.prefix.starts_with(&child.prefix),
+            nxt.prefix.starts_with(&cur.prefix),
             "unexpected error found: prefix order invariant violated"
         );
 
-        if child.key_count == parent.key_count {
+        if cur.key_count == nxt.key_count {
             assert_eq!(
-                child.total_size, parent.total_size,
+                cur.total_size, nxt.total_size,
                 "unexpected error found: total_size should be equal when key_count is equal"
             );
             continue;
         }
 
         assert!(
-            child.key_count > parent.key_count,
+            cur.key_count > nxt.key_count,
             "unexpected error found: key_count should be greater when total_size is greater"
         );
         assert!(
-            child.total_size > parent.total_size,
+            cur.total_size > nxt.total_size,
             "unexpected error found: total_size should be greater when key_count is greater"
         );
-
-        let total_size_fmt = crate::helper::format_bytesize(child.total_size);
+        {
+            let total_size_fmt = crate::helper::format_bytesize(cur.total_size);
+            tracing::info!(
+                operation = "significant_prefix_discovered",
+                prefix = %String::from_utf8_lossy(&cur.prefix),
+                total_size = %total_size_fmt,
+                key_count = cur.key_count,
+                "Discovered new significant prefix"
+            );
+        }
+        out.push(cur.clone());
+    }
+    // last one is the longest prefix, always should be pushed
+    if let Some(last) = agg.last() {
+        let total_size_fmt = crate::helper::format_bytesize(last.total_size);
         tracing::info!(
             operation = "significant_prefix_discovered",
-            prefix = %String::from_utf8_lossy(&child.prefix),
+            prefix = %String::from_utf8_lossy(&last.prefix),
             total_size = %total_size_fmt,
-            key_count = child.key_count,
+            key_count = last.key_count,
             "Discovered new significant prefix"
         );
-        out.push(child.clone());
+        out.push(last.clone());
     }
-
-    let last = agg.first().cloned().expect("agg not empty");
-    let total_size_fmt = crate::helper::format_bytesize(last.total_size);
-    tracing::info!(
-        operation = "significant_prefix_discovered",
-        prefix = %String::from_utf8_lossy(&last.prefix),
-        total_size = %total_size_fmt,
-        key_count = last.key_count,
-        "Discovered new significant prefix"
-    );
-    out.push(last);
 }
 
 #[cfg(test)]
@@ -403,18 +412,18 @@ mod tests {
             Case {
                 name: "nested_identical",
                 input: vec![
-                    make_prefix(b"foo", 100, 3),
-                    make_prefix(b"fo", 100, 3),
                     make_prefix(b"f", 100, 3),
+                    make_prefix(b"fo", 100, 3),
+                    make_prefix(b"foo", 100, 3),
                 ],
                 expect: vec![make_prefix(b"foo", 100, 3)],
             },
             Case {
                 name: "nested_different",
                 input: vec![
-                    make_prefix(b"foo", 30, 1),
-                    make_prefix(b"fo", 50, 2),
                     make_prefix(b"f", 100, 3),
+                    make_prefix(b"fo", 50, 2),
+                    make_prefix(b"foo", 30, 1),
                 ],
                 expect: vec![
                     make_prefix(b"f", 100, 3),
@@ -425,18 +434,17 @@ mod tests {
             Case {
                 name: "nested_same_size",
                 input: vec![
-                    make_prefix(b"foo", 30, 1),
-                    make_prefix(b"fo", 30, 1),
                     make_prefix(b"f", 100, 3),
+                    make_prefix(b"fo", 30, 1),
+                    make_prefix(b"foo", 30, 1),
                 ],
                 expect: vec![make_prefix(b"f", 100, 3), make_prefix(b"foo", 30, 1)],
             },
         ];
 
         for case in cases {
-            let input = case.input;
             let mut out = Vec::new();
-            deduplicate_push(&input, &mut out);
+            deduplicate_push(case.input, &mut out);
             assert_eq!(out, case.expect, "{}: {:?}", case.name, out);
         }
     }
@@ -454,27 +462,25 @@ mod tests {
             total_size: 1,
             key_count: 1,
         };
-        let input = vec![a, b];
         let mut out = Vec::new();
-        deduplicate_push(&input, &mut out);
+        deduplicate_push(vec![a, b], &mut out);
     }
 
     #[test]
     #[should_panic(expected = "prefix order invariant violated")]
     fn dedup_prefix_order_invariant_violation() {
         let cur = PrefixAggregate {
-            prefix: Bytes::from_static(b"bc"),
+            prefix: Bytes::from_static(b"a"),
             total_size: 10,
             key_count: 5,
         };
         let nxt = PrefixAggregate {
-            prefix: Bytes::from_static(b"a"),
+            prefix: Bytes::from_static(b"bc"),
             total_size: 5,
             key_count: 2,
         };
-        let input = vec![cur, nxt];
         let mut out = Vec::new();
-        deduplicate_push(&input, &mut out);
+        deduplicate_push(vec![cur, nxt], &mut out);
     }
 
     #[test]
@@ -490,45 +496,42 @@ mod tests {
             total_size: 5,
             key_count: 2,
         };
-        let input = vec![nxt, cur];
         let mut out = Vec::new();
-        deduplicate_push(&input, &mut out);
+        deduplicate_push(vec![cur, nxt], &mut out);
     }
 
     #[test]
     #[should_panic(expected = "key_count should be greater when total_size is greater")]
     fn dedup_key_count_invariant_violation() {
-        let deeper = PrefixAggregate {
-            prefix: Bytes::from_static(b"ab"),
-            total_size: 50,
-            key_count: 2,
-        };
-        let shallower = PrefixAggregate {
+        let cur = PrefixAggregate {
             prefix: Bytes::from_static(b"a"),
             total_size: 100,
             key_count: 1,
         };
-        let input = vec![deeper, shallower];
+        let nxt = PrefixAggregate {
+            prefix: Bytes::from_static(b"ab"),
+            total_size: 50,
+            key_count: 2,
+        };
         let mut out = Vec::new();
-        deduplicate_push(&input, &mut out);
+        deduplicate_push(vec![cur, nxt], &mut out);
     }
 
     #[test]
     #[should_panic(expected = "total_size should be greater when key_count is greater")]
     fn dedup_total_size_invariant_violation() {
-        let deeper = PrefixAggregate {
-            prefix: Bytes::from_static(b"ab"),
-            total_size: 50,
-            key_count: 1,
-        };
-        let shallower = PrefixAggregate {
+        let cur = PrefixAggregate {
             prefix: Bytes::from_static(b"a"),
-            total_size: 40,
+            total_size: 10,
             key_count: 3,
         };
-        let input = vec![deeper, shallower];
+        let nxt = PrefixAggregate {
+            prefix: Bytes::from_static(b"ab"),
+            total_size: 20,
+            key_count: 2,
+        };
         let mut out = Vec::new();
-        deduplicate_push(&input, &mut out);
+        deduplicate_push(vec![cur, nxt], &mut out);
     }
 }
 


### PR DESCRIPTION
  ## Summary
  - enrich report progress logs with rows-per-second throughput information