### PR TITLE
feat(ci): add reusable LOC badge action and replace tokei.rs badge

### DIFF
--- a/.github/actions/loc-badge/.gitignore
+++ b/.github/actions/loc-badge/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.pnpm-store/

--- a/.github/actions/loc-badge/README.md
+++ b/.github/actions/loc-badge/README.md
@@ -1,10 +1,13 @@
 # loc-badge action
 
-Generate a static SVG LOC badge using built-in JavaScript logic, optional commit/push, and step summary output.
+Generate a static SVG LOC badge with runtime-installed dependencies, optional commit/push, and step summary output.
 
 ## Features
 
 - Generate LOC SVG badge at a configurable path
+- Support configurable badge style (`flat`, `flat-square`, `for-the-badge`, `plastic`, `social`)
+- Install `tokei` via `taiki-e/install-action` during workflow runtime
+- Install npm runtime dependency with `pnpm` + lockfile during workflow runtime
 - Auto commit and push badge updates when content changes
 - Support dry-run mode (compute and summarize without commit/push)
 
@@ -15,8 +18,8 @@ Generate a static SVG LOC badge using built-in JavaScript logic, optional commit
 | `badge_path` | No | `.github/badges/loc.svg` | Output path for the generated SVG badge. |
 | `scope` | No | `code` | LOC scope: `code`, `code_comments`, `all`. |
 | `label` | No | `lines of code` | Badge label text. |
+| `style` | No | `flat` | Badge style: `flat`, `flat-square`, `for-the-badge`, `plastic`, `social`. |
 | `exclude` | No | `""` | Optional comma-separated extra excludes; `badge_path` is always excluded automatically. |
-| `tokei_version` | No | `latest` | Tokei version for `cargo install` (e.g. `12.1.2`). |
 | `dry_run` | No | `false` | If `true`, only generate badge and summary without commit/push. |
 | `commit_message` | No | `ci(badge): refresh loc badge` | Commit message used when badge changes and `dry_run=false`. |
 | `commit_user_name` | No | `github-actions[bot]` | Git author name for auto commit. |

--- a/.github/actions/loc-badge/README.md
+++ b/.github/actions/loc-badge/README.md
@@ -1,0 +1,55 @@
+# loc-badge action
+
+Generate a static SVG LOC badge using built-in JavaScript logic, optional commit/push, and step summary output.
+
+## Features
+
+- Generate LOC SVG badge at a configurable path
+- Auto commit and push badge updates when content changes
+- Support dry-run mode (compute and summarize without commit/push)
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `badge_path` | No | `.github/badges/loc.svg` | Output path for the generated SVG badge. |
+| `scope` | No | `code` | LOC scope: `code`, `code_comments`, `all`. |
+| `label` | No | `lines of code` | Badge label text. |
+| `exclude` | No | `""` | Optional comma-separated extra excludes; `badge_path` is always excluded automatically. |
+| `tokei_version` | No | `latest` | Tokei version for `cargo install` (e.g. `12.1.2`). |
+| `dry_run` | No | `false` | If `true`, only generate badge and summary without commit/push. |
+| `commit_message` | No | `ci(badge): refresh loc badge` | Commit message used when badge changes and `dry_run=false`. |
+| `commit_user_name` | No | `github-actions[bot]` | Git author name for auto commit. |
+| `commit_user_email` | No | `41898282+github-actions[bot]@users.noreply.github.com` | Git author email for auto commit. |
+| `github_token` | No | `${{ github.token }}` | Token used for authenticated push. |
+| `target_branch` | No | auto | Branch to push to; defaults to `GITHUB_HEAD_REF` or `GITHUB_REF_NAME`. |
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `changed` | Whether `badge_path` changed after generation. |
+| `committed` | Whether a commit was created. |
+| `pushed` | Whether the commit was pushed. |
+| `value` | Computed LOC value (raw integer). |
+
+## Example (auto commit/push)
+
+```yaml
+- uses: actions/checkout@v4
+
+- uses: DCjanus/rdbinsight/.github/actions/loc-badge@master
+```
+
+## Example (dry run)
+
+```yaml
+- uses: actions/checkout@v4
+
+- id: loc_badge
+  uses: DCjanus/rdbinsight/.github/actions/loc-badge@master
+  with:
+    dry_run: true
+
+- run: echo "LOC value = ${{ steps.loc_badge.outputs.value }}"
+```

--- a/.github/actions/loc-badge/action.yml
+++ b/.github/actions/loc-badge/action.yml
@@ -30,7 +30,7 @@ inputs:
   commit_message:
     description: Commit message used when badge changes and dry_run is false.
     required: false
-    default: ci(badge): refresh loc badge
+    default: "ci(badge): refresh loc badge"
   commit_user_name:
     description: Git author name for auto commit.
     required: false

--- a/.github/actions/loc-badge/action.yml
+++ b/.github/actions/loc-badge/action.yml
@@ -76,7 +76,7 @@ runs:
       with:
         node-version: "24"
         cache: "pnpm"
-        cache-dependency-path: ${{ github.action_path }}/pnpm-lock.yaml
+        cache-dependency-path: .github/actions/loc-badge/pnpm-lock.yaml
 
     - name: Install tokei
       uses: taiki-e/install-action@v2

--- a/.github/actions/loc-badge/action.yml
+++ b/.github/actions/loc-badge/action.yml
@@ -1,0 +1,63 @@
+name: LOC Badge Generator
+description: Generate, optionally commit, and optionally push an SVG LOC badge.
+author: DCjanus
+
+inputs:
+  badge_path:
+    description: Output path for the generated SVG badge.
+    required: false
+    default: .github/badges/loc.svg
+  scope:
+    description: LOC scope (code, code_comments, all).
+    required: false
+    default: code
+  label:
+    description: Badge label text.
+    required: false
+    default: lines of code
+  exclude:
+    description: Optional comma-separated extra exclude patterns. badge_path is always excluded automatically.
+    required: false
+    default: ""
+  tokei_version:
+    description: Tokei version (latest or a release tag like v12.1.2).
+    required: false
+    default: latest
+  dry_run:
+    description: If true, only generate badge and summary without commit/push.
+    required: false
+    default: "false"
+  commit_message:
+    description: Commit message used when badge changes and dry_run is false.
+    required: false
+    default: ci(badge): refresh loc badge
+  commit_user_name:
+    description: Git author name for auto commit.
+    required: false
+    default: github-actions[bot]
+  commit_user_email:
+    description: Git author email for auto commit.
+    required: false
+    default: 41898282+github-actions[bot]@users.noreply.github.com
+  github_token:
+    description: Token used for authenticated push. Defaults to github.token.
+    required: false
+    default: ${{ github.token }}
+  target_branch:
+    description: Branch to push to. Defaults to GITHUB_HEAD_REF or GITHUB_REF_NAME.
+    required: false
+    default: ""
+
+outputs:
+  changed:
+    description: Whether badge_path changed after generation.
+  committed:
+    description: Whether a commit was created.
+  pushed:
+    description: Whether the commit was pushed.
+  value:
+    description: Computed LOC value (raw integer).
+
+runs:
+  using: node20
+  main: index.js

--- a/.github/actions/loc-badge/action.yml
+++ b/.github/actions/loc-badge/action.yml
@@ -15,14 +15,14 @@ inputs:
     description: Badge label text.
     required: false
     default: lines of code
+  style:
+    description: Badge style. Supports flat, flat-square, for-the-badge, plastic, social.
+    required: false
+    default: flat
   exclude:
     description: Optional comma-separated extra exclude patterns. badge_path is always excluded automatically.
     required: false
     default: ""
-  tokei_version:
-    description: Tokei version (latest or a release tag like v12.1.2).
-    required: false
-    default: latest
   dry_run:
     description: If true, only generate badge and summary without commit/push.
     required: false
@@ -51,13 +51,54 @@ inputs:
 outputs:
   changed:
     description: Whether badge_path changed after generation.
+    value: ${{ steps.run.outputs.changed }}
   committed:
     description: Whether a commit was created.
+    value: ${{ steps.run.outputs.committed }}
   pushed:
     description: Whether the commit was pushed.
+    value: ${{ steps.run.outputs.pushed }}
   value:
     description: Computed LOC value (raw integer).
+    value: ${{ steps.run.outputs.value }}
 
 runs:
-  using: node20
-  main: index.js
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
+        run_install: false
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24"
+        cache: "pnpm"
+        cache-dependency-path: ${{ github.action_path }}/pnpm-lock.yaml
+
+    - name: Install tokei
+      uses: taiki-e/install-action@tokei
+
+    - name: Install badge-maker runtime dependency
+      shell: bash
+      run: pnpm --dir "${{ github.action_path }}" install --prod --frozen-lockfile
+
+    - name: Run loc badge generator
+      id: run
+      shell: bash
+      env:
+        INPUT_BADGE_PATH: ${{ inputs.badge_path }}
+        INPUT_SCOPE: ${{ inputs.scope }}
+        INPUT_LABEL: ${{ inputs.label }}
+        INPUT_STYLE: ${{ inputs.style }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        INPUT_COMMIT_MESSAGE: ${{ inputs.commit_message }}
+        INPUT_COMMIT_USER_NAME: ${{ inputs.commit_user_name }}
+        INPUT_COMMIT_USER_EMAIL: ${{ inputs.commit_user_email }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_TARGET_BRANCH: ${{ inputs.target_branch }}
+        NODE_PATH: ${{ github.action_path }}/node_modules
+      run: node "${{ github.action_path }}/index.js"

--- a/.github/actions/loc-badge/action.yml
+++ b/.github/actions/loc-badge/action.yml
@@ -79,7 +79,9 @@ runs:
         cache-dependency-path: ${{ github.action_path }}/pnpm-lock.yaml
 
     - name: Install tokei
-      uses: taiki-e/install-action@tokei
+      uses: taiki-e/install-action@v2
+      with:
+        tool: tokei
 
     - name: Install badge-maker runtime dependency
       shell: bash

--- a/.github/actions/loc-badge/index.js
+++ b/.github/actions/loc-badge/index.js
@@ -41,7 +41,17 @@ function runStatus(cmd, args, options = {}) {
 }
 
 function commandExists(cmd) {
-  return runStatus(cmd, ["--version"], { capture: true }).status === 0;
+  const result = spawnSync(cmd, ["--version"], {
+    encoding: "utf8",
+    stdio: "ignore",
+  });
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      return false;
+    }
+    throw result.error;
+  }
+  return result.status === 0;
 }
 
 function setOutput(name, value) {

--- a/.github/actions/loc-badge/index.js
+++ b/.github/actions/loc-badge/index.js
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+function getInput(name, defaultValue = "") {
+  const key = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+  return process.env[key] ?? defaultValue;
+}
+
+function parseBool(value, defaultValue = false) {
+  if (value == null || value === "") return defaultValue;
+  const v = String(value).trim().toLowerCase();
+  return ["1", "true", "yes", "on"].includes(v);
+}
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    encoding: "utf8",
+    stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    ...options,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr}` : "";
+    throw new Error(`Command failed: ${cmd} ${args.join(" ")}${stderr}`);
+  }
+  return result.stdout ?? "";
+}
+
+function runStatus(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    encoding: "utf8",
+    stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    ...options,
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function commandExists(cmd) {
+  return runStatus(cmd, ["--version"], { capture: true }).status === 0;
+}
+
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    fs.appendFileSync(outputFile, `${name}=${value}\n`);
+  } else {
+    console.log(`::set-output name=${name}::${value}`);
+  }
+}
+
+function appendSummary(lines) {
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (!summary) return;
+  fs.appendFileSync(summary, `${lines.join("\n")}\n`);
+}
+
+function addToPath(dir) {
+  process.env.PATH = `${dir}${path.delimiter}${process.env.PATH || ""}`;
+  const githubPath = process.env.GITHUB_PATH;
+  if (githubPath) {
+    fs.appendFileSync(githubPath, `${dir}\n`);
+  }
+}
+
+function escapeXml(value) {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function normalizeRemoteWithToken(token) {
+  if (!token) return;
+
+  const origin = run("git", ["remote", "get-url", "origin"], { capture: true }).trim();
+  let normalized = "";
+
+  if (origin.startsWith("git@github.com:")) {
+    normalized = `https://x-access-token:${encodeURIComponent(token)}@github.com/${origin.slice("git@github.com:".length)}`;
+  } else if (origin.startsWith("https://github.com/")) {
+    normalized = origin.replace("https://", `https://x-access-token:${encodeURIComponent(token)}@`);
+  } else if (origin.startsWith("http://github.com/")) {
+    normalized = origin.replace("http://", `https://x-access-token:${encodeURIComponent(token)}@`);
+  }
+
+  if (normalized) {
+    run("git", ["remote", "set-url", "origin", normalized]);
+  }
+}
+
+function installTokei(version) {
+  if (commandExists("tokei")) {
+    return;
+  }
+
+  if (!commandExists("cargo")) {
+    throw new Error("tokei is missing and cargo is unavailable. Please use a runner with Rust toolchain installed.");
+  }
+
+  const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), "loc-badge-cargo-"));
+  const args = ["install", "--locked", "tokei", "--root", installRoot];
+  if (version !== "latest") {
+    args.push("--version", version);
+  }
+  run("cargo", args);
+
+  const binDir = path.join(installRoot, "bin");
+  const binName = process.platform === "win32" ? "tokei.exe" : "tokei";
+  const binPath = path.join(binDir, binName);
+  if (!fs.existsSync(binPath)) {
+    throw new Error(`tokei install completed but binary not found at ${binPath}`);
+  }
+  addToPath(binDir);
+  run("tokei", ["--version"]);
+}
+
+function parseTotalsFromTokei(jsonText) {
+  const parsed = JSON.parse(jsonText);
+
+  if (parsed.Total) {
+    return {
+      code: Number(parsed.Total.code || 0),
+      comments: Number(parsed.Total.comments || 0),
+      blanks: Number(parsed.Total.blanks || 0),
+    };
+  }
+
+  const total = { code: 0, comments: 0, blanks: 0 };
+  for (const [lang, stat] of Object.entries(parsed)) {
+    if (lang === "Total" || !stat || typeof stat !== "object") continue;
+    total.code += Number(stat.code || 0);
+    total.comments += Number(stat.comments || 0);
+    total.blanks += Number(stat.blanks || 0);
+  }
+  return total;
+}
+
+function generateSvg(label, formattedValue) {
+  const labelW = label.length * 7 + 10;
+  const valueW = formattedValue.length * 7 + 10;
+  const width = labelW + valueW;
+  const labelEscaped = escapeXml(label);
+  const valueEscaped = escapeXml(formattedValue);
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="20" role="img" aria-label="${labelEscaped}: ${valueEscaped}">`,
+    `  <title>${labelEscaped}: ${valueEscaped}</title>`,
+    `  <rect width="${labelW}" height="20" fill="#555"/>`,
+    `  <rect x="${labelW}" width="${valueW}" height="20" fill="#4c1"/>`,
+    `  <text x="${Math.floor(labelW / 2)}" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">${labelEscaped}</text>`,
+    `  <text x="${labelW + Math.floor(valueW / 2)}" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">${valueEscaped}</text>`,
+    "</svg>",
+    "",
+  ].join("\n");
+}
+
+async function main() {
+  const badgePath = getInput("badge_path", ".github/badges/loc.svg");
+  const scope = getInput("scope", "code");
+  const label = getInput("label", "lines of code");
+  const exclude = getInput("exclude", "");
+  const tokeiVersion = getInput("tokei_version", "latest");
+  const dryRun = parseBool(getInput("dry_run", "false"), false);
+  const commitMessage = getInput("commit_message", "ci(badge): refresh loc badge");
+  const commitUserName = getInput("commit_user_name", "github-actions[bot]");
+  const commitUserEmail = getInput("commit_user_email", "41898282+github-actions[bot]@users.noreply.github.com");
+  const token = getInput("github_token", "");
+  const targetBranchInput = getInput("target_branch", "").trim();
+
+  installTokei(tokeiVersion);
+
+  fs.mkdirSync(path.dirname(badgePath), { recursive: true });
+
+  const excludePatterns = new Set(
+    exclude
+      .split(",")
+      .map((it) => it.trim())
+      .filter(Boolean),
+  );
+  excludePatterns.add(badgePath);
+
+  const tokeiArgs = [".", "--output", "json"];
+  for (const pattern of excludePatterns) {
+    tokeiArgs.push("--exclude", pattern);
+  }
+
+  const tokeiJson = run("tokei", tokeiArgs, { capture: true });
+  const totals = parseTotalsFromTokei(tokeiJson);
+
+  let value = 0;
+  if (scope === "code") {
+    value = totals.code;
+  } else if (scope === "code_comments") {
+    value = totals.code + totals.comments;
+  } else if (scope === "all") {
+    value = totals.code + totals.comments + totals.blanks;
+  } else {
+    throw new Error(`Unsupported scope: ${scope} (expected: code|code_comments|all)`);
+  }
+
+  const valueText = formatNumber(value);
+  const svg = generateSvg(label, valueText);
+  fs.writeFileSync(badgePath, svg, "utf8");
+
+  const changed = runStatus("git", ["diff", "--quiet", "--", badgePath]).status !== 0;
+  let committed = false;
+  let pushed = false;
+
+  if (changed && !dryRun) {
+    run("git", ["config", "user.name", commitUserName]);
+    run("git", ["config", "user.email", commitUserEmail]);
+    run("git", ["add", badgePath]);
+
+    const stagedChanged = runStatus("git", ["diff", "--cached", "--quiet"]).status !== 0;
+    if (stagedChanged) {
+      run("git", ["commit", "-m", commitMessage]);
+      committed = true;
+
+      try {
+        normalizeRemoteWithToken(token);
+        const branch = targetBranchInput || process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME;
+        if (!branch) throw new Error("Cannot determine target branch for push.");
+        run("git", ["push", "origin", `HEAD:${branch}`]);
+        pushed = true;
+      } catch (error) {
+        const msg = String(error && error.message ? error.message : error);
+        console.log(`::warning::LOC badge push failed: ${msg}`);
+        appendSummary([
+          "### LOC badge update warning",
+          "",
+          `Computed LOC value \`${valueText}\` and updated \`${badgePath}\`, but push failed:`,
+          "",
+          "```text",
+          msg,
+          "```",
+        ]);
+      }
+    }
+  }
+
+  appendSummary([
+    "### LOC badge",
+    "",
+    `- Path: \`${badgePath}\``,
+    `- Scope: \`${scope}\``,
+    `- Value: \`${valueText}\``,
+    `- Changed: \`${changed}\``,
+    `- Committed: \`${committed}\``,
+    `- Pushed: \`${pushed}\``,
+  ]);
+
+  setOutput("changed", String(changed));
+  setOutput("committed", String(committed));
+  setOutput("pushed", String(pushed));
+  setOutput("value", String(value));
+}
+
+main().catch((error) => {
+  const message = String(error && error.message ? error.message : error);
+  console.error(message);
+  console.log(`::error::${message.replace(/\n/g, " ")}`);
+  process.exit(1);
+});

--- a/.github/actions/loc-badge/index.js
+++ b/.github/actions/loc-badge/index.js
@@ -218,7 +218,7 @@ async function main() {
   const svg = generateSvg(label, valueText);
   fs.writeFileSync(badgePath, svg, "utf8");
 
-  const changed = runStatus("git", ["diff", "--quiet", "--", badgePath]).status !== 0;
+  const changed = run("git", ["status", "--porcelain", "--", badgePath], { capture: true }).trim().length > 0;
   let committed = false;
   let pushed = false;
 

--- a/.github/actions/loc-badge/package.json
+++ b/.github/actions/loc-badge/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "loc-badge",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.29.2",
+  "dependencies": {
+    "badge-maker": "^5.0.2"
+  }
+}

--- a/.github/actions/loc-badge/package.json
+++ b/.github/actions/loc-badge/package.json
@@ -1,14 +1,18 @@
 {
   "name": "loc-badge",
   "version": "1.0.0",
-  "description": "",
+  "description": "Reusable GitHub Action to generate, style, and sync LOC SVG badges using tokei.",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "github-action",
+    "badge",
+    "loc",
+    "tokei",
+    "svg",
+    "pnpm"
+  ],
+  "author": "DCjanus <DCjanus@dcjanus.com>",
+  "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "dependencies": {
     "badge-maker": "^5.0.2"

--- a/.github/actions/loc-badge/pnpm-lock.yaml
+++ b/.github/actions/loc-badge/pnpm-lock.yaml
@@ -1,0 +1,70 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      badge-maker:
+        specifier: ^5.0.2
+        version: 5.0.2
+
+packages:
+
+  anafanafo@2.0.0:
+    resolution: {integrity: sha512-Nlfq7NC4AOkTJerWRIZcOAiMNtIDVIGWGvQ98O7Jl6Kr2Dk0dX5u4MqN778kSRTy5KRqchpLdF2RtLFEz9FVkQ==}
+
+  badge-maker@5.0.2:
+    resolution: {integrity: sha512-Xd3YUmKPEShQcn6PFB03Wxq0RNJRFwVVroyRz0qIjSXwniYUGsGWNHqtNsQYi/Sbs8Ni7qAEf7LKgDOtcAoCDg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  binary-search@1.3.6:
+    resolution: {integrity: sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==}
+
+  char-width-table-consumer@1.0.0:
+    resolution: {integrity: sha512-Fz4UD0LBpxPgL9i29CJ5O4KANwaMnX/OhhbxzvNa332h+9+nRKyeuLw4wA51lt/ex67+/AdsoBQJF3kgX2feYQ==}
+
+  color-convert@0.5.3:
+    resolution: {integrity: sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  css-color-converter@2.0.0:
+    resolution: {integrity: sha512-oLIG2soZz3wcC3aAl/7Us5RS8Hvvc6I8G8LniF/qfMmrm7fIKQ8RIDDRZeKyGL2SrWfNqYspuLShbnjBMVWm8g==}
+
+  css-unit-converter@1.1.2:
+    resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
+
+snapshots:
+
+  anafanafo@2.0.0:
+    dependencies:
+      char-width-table-consumer: 1.0.0
+
+  badge-maker@5.0.2:
+    dependencies:
+      anafanafo: 2.0.0
+      css-color-converter: 2.0.0
+
+  binary-search@1.3.6: {}
+
+  char-width-table-consumer@1.0.0:
+    dependencies:
+      binary-search: 1.3.6
+
+  color-convert@0.5.3: {}
+
+  color-name@1.1.4: {}
+
+  css-color-converter@2.0.0:
+    dependencies:
+      color-convert: 0.5.3
+      color-name: 1.1.4
+      css-unit-converter: 1.1.2
+
+  css-unit-converter@1.1.2: {}

--- a/.github/badges/loc.svg
+++ b/.github/badges/loc.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="lines of code: 17,420">
+  <title>lines of code: 17,420</title>
+  <rect width="101" height="20" fill="#555"/>
+  <rect x="101" width="52" height="20" fill="#4c1"/>
+  <text x="50" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">lines of code</text>
+  <text x="127" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">17,420</text>
+</svg>

--- a/.github/badges/loc.svg
+++ b/.github/badges/loc.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="lines of code: 17,420">
-  <title>lines of code: 17,420</title>
-  <rect width="101" height="20" fill="#555"/>
-  <rect x="101" width="52" height="20" fill="#4c1"/>
-  <text x="50" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">lines of code</text>
-  <text x="127" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">17,420</text>
-</svg>

--- a/.github/badges/loc.svg
+++ b/.github/badges/loc.svg
@@ -1,7 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="153" height="20" role="img" aria-label="lines of code: 17,420">
-  <title>lines of code: 17,420</title>
-  <rect width="101" height="20" fill="#555"/>
-  <rect x="101" width="52" height="20" fill="#4c1"/>
-  <text x="50" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">lines of code</text>
-  <text x="127" y="14" fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">17,420</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="20" role="img" aria-label="lines of code: 17,420"><title>lines of code: 17,420</title><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="128" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#r)"><rect width="79" height="20" fill="#555"/><rect x="79" width="49" height="20" fill="#4c1"/><rect width="128" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><text aria-hidden="true" x="405" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="690">lines of code</text><text x="405" y="140" transform="scale(.1)" fill="#fff" textLength="690">lines of code</text><text aria-hidden="true" x="1025" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="390">17,420</text><text x="1025" y="140" transform="scale(.1)" fill="#fff" textLength="390">17,420</text></g></svg>

--- a/.github/workflows/loc-badge.yml
+++ b/.github/workflows/loc-badge.yml
@@ -1,0 +1,32 @@
+name: LOC Badge
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - ".github/badges/loc.svg"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-loc-badge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate and sync LOC badge
+        id: loc_badge
+        uses: ./.github/actions/loc-badge
+        with:
+          badge_path: .github/badges/loc.svg
+          scope: code
+          label: lines of code

--- a/.github/workflows/loc-badge.yml
+++ b/.github/workflows/loc-badge.yml
@@ -26,7 +26,3 @@ jobs:
       - name: Generate and sync LOC badge
         id: loc_badge
         uses: ./.github/actions/loc-badge
-        with:
-          badge_path: .github/badges/loc.svg
-          scope: code
-          label: lines of code

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/DCjanus/rdbinsight/graph/badge.svg?token=KXVIGig53g)](https://codecov.io/gh/DCjanus/rdbinsight)
 [![dependency status](https://deps.rs/repo/github/dcjanus/rdbinsight/status.svg)](https://deps.rs/repo/github/dcjanus/rdbinsight)
 [![Docker Image Version](https://ghcr-badge.egpl.dev/dcjanus/rdbinsight/latest_tag?color=%2344cc11&ignore=latest&label=docker+image&trim=)](https://github.com/DCjanus/rdbinsight/pkgs/container/rdbinsight)
-[![Lines of Code](https://tokei.rs/b1/github/DCjanus/rdbinsight?style=flat)](https://github.com/DCjanus/rdbinsight)
+[![Lines of Code](https://raw.githubusercontent.com/DCjanus/rdbinsight/master/.github/badges/loc.svg)](https://github.com/DCjanus/rdbinsight)
 
 RDBInsight is a Redis analysis and diagnostic tool that converts RDB snapshots into structured data suitable for OLAP workloads, helping engineers investigate memory and performance issues.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/DCjanus/rdbinsight/graph/badge.svg?token=KXVIGig53g)](https://codecov.io/gh/DCjanus/rdbinsight)
 [![dependency status](https://deps.rs/repo/github/dcjanus/rdbinsight/status.svg)](https://deps.rs/repo/github/dcjanus/rdbinsight)
 [![Docker Image Version](https://ghcr-badge.egpl.dev/dcjanus/rdbinsight/latest_tag?color=%2344cc11&ignore=latest&label=docker+image&trim=)](https://github.com/DCjanus/rdbinsight/pkgs/container/rdbinsight)
-[![Lines of Code](https://raw.githubusercontent.com/DCjanus/rdbinsight/master/.github/badges/loc.svg)](https://github.com/DCjanus/rdbinsight)
+[![Lines of Code](.github/badges/loc.svg)](https://github.com/DCjanus/rdbinsight)
 
 RDBInsight is a Redis analysis and diagnostic tool that converts RDB snapshots into structured data suitable for OLAP workloads, helping engineers investigate memory and performance issues.
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/DCjanus/rdbinsight/graph/badge.svg?token=KXVIGig53g)](https://codecov.io/gh/DCjanus/rdbinsight)
 [![dependency status](https://deps.rs/repo/github/dcjanus/rdbinsight/status.svg)](https://deps.rs/repo/github/dcjanus/rdbinsight)
 [![Docker Image Version](https://ghcr-badge.egpl.dev/dcjanus/rdbinsight/latest_tag?color=%2344cc11&ignore=latest&label=docker+image&trim=)](https://github.com/DCjanus/rdbinsight/pkgs/container/rdbinsight)
-[![Lines of Code](https://raw.githubusercontent.com/DCjanus/rdbinsight/master/.github/badges/loc.svg)](https://github.com/DCjanus/rdbinsight)
+[![Lines of Code](.github/badges/loc.svg)](https://github.com/DCjanus/rdbinsight)
 
 RDBInsight 是面向 Redis 的分析与诊断工具。它将 RDB 快照解析为便于 OLAP 分析的结构化元数据，帮助快速定位内存与性能相关的问题。
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/DCjanus/rdbinsight/graph/badge.svg?token=KXVIGig53g)](https://codecov.io/gh/DCjanus/rdbinsight)
 [![dependency status](https://deps.rs/repo/github/dcjanus/rdbinsight/status.svg)](https://deps.rs/repo/github/dcjanus/rdbinsight)
 [![Docker Image Version](https://ghcr-badge.egpl.dev/dcjanus/rdbinsight/latest_tag?color=%2344cc11&ignore=latest&label=docker+image&trim=)](https://github.com/DCjanus/rdbinsight/pkgs/container/rdbinsight)
-[![Lines of Code](https://tokei.rs/b1/github/DCjanus/rdbinsight?style=flat)](https://github.com/DCjanus/rdbinsight)
+[![Lines of Code](https://raw.githubusercontent.com/DCjanus/rdbinsight/master/.github/badges/loc.svg)](https://github.com/DCjanus/rdbinsight)
 
 RDBInsight 是面向 Redis 的分析与诊断工具。它将 RDB 快照解析为便于 OLAP 分析的结构化元数据，帮助快速定位内存与性能相关的问题。
 


### PR DESCRIPTION
## Summary
- Replace deprecated `tokei.rs` README badges with an in-repo SVG badge.
- Add reusable `loc-badge` GitHub Action to generate/update the badge automatically.

## What changed
- Added reusable action at `.github/actions/loc-badge` (composite action).
- Action installs `tokei` and runtime deps, generates badge SVG with style support, and can auto commit/push.
- Added workflow `.github/workflows/loc-badge.yml` to keep badge updated on pushes.
- Updated `README.md` and `README.zh_CN.md` to reference `.github/badges/loc.svg`.

## Verification
- `update-loc-badge` workflow now passes on this PR.
