### PR TITLE
ci: split checks and cache coverage builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
-    name: Check (fmt + clippy + tests)
+  lint:
+    name: Lint (fmt + clippy)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,27 +31,51 @@ jobs:
         id: toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          components: rustfmt, llvm-tools-preview, clippy
+          components: rustfmt, clippy
 
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Enable sccache for Rust builds
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-
 
       - name: Run cargo fmt --check (nightly)
         run: cargo +nightly fmt --all -- --check
 
       - name: Run cargo clippy (nightly)
         run: cargo +nightly clippy --all -- -D warnings
+
+  coverage:
+    name: Coverage (llvm-cov + nextest)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install nightly Rust toolchain (llvm-tools-preview)
+        id: toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate coverage report (cargo llvm-cov + nextest)
         run: |
@@ -68,13 +91,9 @@ jobs:
           files: codecov.json
           fail_ci_if_error: true
 
-      - name: Show sccache stats
-        if: always()
-        run: ${SCCACHE_PATH} --show-stats
-
   docker-builds:
     name: Docker Build (${{ matrix.name }})
-    needs: [check]
+    needs: [lint, coverage]
     if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
         with:
           components: llvm-tools-preview
 
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache for Rust builds
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 
@@ -74,6 +82,10 @@ jobs:
           use_oidc: true
           files: codecov.json
           fail_ci_if_error: true
+
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH} --show-stats
 
   docker-builds:
     name: Docker Build (${{ matrix.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
         with:
           components: rustfmt, llvm-tools-preview, clippy
 
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache for Rust builds
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -67,6 +67,10 @@ jobs:
           use_oidc: true
           files: codecov.json
           fail_ci_if_error: true
+
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH} --show-stats
 
   docker-builds:
     name: Docker Build (${{ matrix.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,19 +33,23 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache for Rust builds
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Run cargo fmt --check (nightly)
         run: cargo +nightly fmt --all -- --check
 
       - name: Run cargo clippy (nightly)
         run: cargo +nightly clippy --all -- -D warnings
+
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH} --show-stats
 
   coverage:
     name: Coverage (llvm-cov + nextest)
@@ -63,13 +67,13 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ steps.toolchain.outputs.cachekey }}-
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache for Rust builds
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -90,6 +94,10 @@ jobs:
           use_oidc: true
           files: codecov.json
           fail_ci_if_error: true
+
+      - name: Show sccache stats
+        if: always()
+        run: ${SCCACHE_PATH} --show-stats
 
   docker-builds:
     name: Docker Build (${{ matrix.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,23 +33,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Enable sccache for Rust builds
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
       - name: Run cargo fmt --check (nightly)
         run: cargo +nightly fmt --all -- --check
 
       - name: Run cargo clippy (nightly)
         run: cargo +nightly clippy --all -- -D warnings
-
-      - name: Show sccache stats
-        if: always()
-        run: ${SCCACHE_PATH} --show-stats
 
   coverage:
     name: Coverage (llvm-cov + nextest)
@@ -66,14 +54,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
-
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Enable sccache for Rust builds
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -94,10 +74,6 @@ jobs:
           use_oidc: true
           files: codecov.json
           fail_ci_if_error: true
-
-      - name: Show sccache stats
-        if: always()
-        run: ${SCCACHE_PATH} --show-stats
 
   docker-builds:
     name: Docker Build (${{ matrix.name }})


### PR DESCRIPTION
## Why

- PR CI should continue running full coverage tests, but the previous single check job made lint and coverage wait on each other.
- The full `target` directory cache is fast on warm runs, but it restores a large archive for every PR check.
- This PR keeps the final diff focused on a smaller cache strategy after comparing `target` cache, `sccache`, and no-cache variants.

## What

- Split PR CI into two parallel jobs:
  - `Lint (fmt + clippy)` runs formatting and clippy without a compiler cache.
  - `Coverage (llvm-cov + nextest)` runs full coverage tests, uploads Codecov results, and uses `sccache`.
- Remove the full `target` directory cache from the PR check path.
- Print `sccache` stats from the coverage job so cache behavior is visible in CI logs.
- Keep Docker image builds gated on both CI jobs for non-PR events.

## Timing Comparison

Observed on GitHub-hosted runners for this PR investigation. Times include normal runner variance, so the conclusion uses relative patterns across multiple runs instead of a single sample.

| Variant | Cache strategy | Job layout | Lint / clippy job | Coverage job | PR critical path | Cache signal | Result |
| --- | --- | --- | ---: | ---: | ---: | --- | --- |
| Existing warm PR CI | Full `target` cache | Single job | ~8-9s clippy step | ~1m35-1m36 coverage step | ~2m32-2m34 | Restores ~1.5GB `target` cache | Fastest warm path, but keeps large archive restore |
| Single job + `sccache` cold | `sccache` for all Rust builds | Single job | 2m02 clippy step | 4m01 coverage step | 6m25 | 0.31% hit rate | Too slow as a cold path |
| Single job + `sccache` rerun | `sccache` for all Rust builds | Single job | 1m43 clippy step | 2m43 coverage step | 4m47 | 58.28% hit rate | Warmer, but still slower than desired |
| Split jobs + full `target` cache | Full `target` cache in both jobs | Parallel jobs | 56s | 3m05 | 3m05 | Duplicates large cache restore across jobs | Splitting alone did not beat existing warm CI |
| Split jobs + `sccache` everywhere | `sccache` in both jobs | Parallel jobs | 1m59 | 3m18 | 3m18 | Lint 80%, coverage 99% hit rate | Coverage benefits, lint does not |
| Split jobs + no cache | No compiler cache | Parallel jobs | 1m43 | 4m05 | 4m05 | No cache overhead | Lint is fine, coverage is too slow |
| Final shape | No cache for lint; `sccache` for coverage | Parallel jobs | 1m41 | 2m59 | 2m59 | Coverage 99% hit rate | Best no-`target`-cache tradeoff observed |

## Conclusion

- `sccache` is worthwhile for the coverage job: it reduced coverage from 4m05 without cache to 2m59 in the final run.
- `sccache` is not worthwhile for the lint job in the observed runs: lint was faster without it.
- Keeping `target` cache remains the fastest warm path in the samples, but the final diff intentionally removes the large full-directory cache and keeps the smaller `sccache` path only where it showed clear benefit.
