### PR TITLE
Support Redis 8.6 stream RDB encoding

### DIFF
--- a/.github/workflows/publish-test-images.yml
+++ b/.github/workflows/publish-test-images.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ["8.0.5", "7.0.15", "6.0.20", "2.8.24"]
+        redis: ["8.6.4", "8.0.5", "7.0.15", "6.0.20", "2.8.24"]
         platform: [amd64, arm64]
         include:
           - platform: amd64
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ["8.0.5", "7.0.15", "6.0.20", "2.8.24"]
+        redis: ["8.6.4", "8.0.5", "7.0.15", "6.0.20", "2.8.24"]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/src/parser/model.rs
+++ b/src/parser/model.rs
@@ -217,6 +217,7 @@ pub enum StreamEncoding {
     ListPacks,
     ListPacks2,
     ListPacks3,
+    ListPacks4,
 }
 
 /// Opcode of RDB, ref: https://github.com/redis/redis/blob/2ba81b70957691a6a010e785225672e6657e53e8/src/rdb.h#L93
@@ -266,6 +267,7 @@ pub enum RDBType {
     HashListPackExPreGA = 23, // RDB_TYPE_HASH_LISTPACK_EX_PRE_GA
     HashMetadata = 24,        // RDB_TYPE_HASH_METADATA
     HashListPackEx = 25,      // RDB_TYPE_HASH_LISTPACK_EX
+    StreamListPacks4 = 26,    // RDB_TYPE_STREAM_LISTPACKS_4
 }
 
 /// Module serialized values sub opcodes, ref: https://github.com/redis/redis/blob/2ba81b70957691a6a010e785225672e6657e53e8/src/rdb.h#L133

--- a/src/parser/rdb_file.rs
+++ b/src/parser/rdb_file.rs
@@ -44,6 +44,7 @@ enum ItemParser {
     StreamListPack(StreamListPackRecordParser<{ StreamEncoding::ListPacks }>),
     StreamListPack2(StreamListPackRecordParser<{ StreamEncoding::ListPacks2 }>),
     StreamListPack3(StreamListPackRecordParser<{ StreamEncoding::ListPacks3 }>),
+    StreamListPack4(StreamListPackRecordParser<{ StreamEncoding::ListPacks4 }>),
     Set(SetRecordParser),
     SetIntSet(SetIntSetRecordParser),
     SetListPack(SetListPackRecordParser),
@@ -87,7 +88,7 @@ impl RDBFileParser {
         let version = std::str::from_utf8(version).context("version should be utf8")?;
         let version: u64 = version.parse().context("version should be a number")?;
         ensure!(version >= 1, "version should be >= 1");
-        ensure!(version <= 12, "version should be <= 12");
+        ensure!(version <= 13, "version should be <= 13");
 
         self.version = version;
         buffer.consume_to(input.as_ptr());
@@ -378,6 +379,14 @@ impl RDBFileParser {
                 RDBType::StreamListPacks3 => {
                     let (input, entrust) = StreamListPackRecordParser::<
                         { StreamEncoding::ListPacks3 },
+                    >::init(buffer, input)?;
+                    buffer.consume_to(input.as_ptr());
+                    let item = self.set_entrust(entrust, buffer)?;
+                    self.return_item(item)
+                }
+                RDBType::StreamListPacks4 => {
+                    let (input, entrust) = StreamListPackRecordParser::<
+                        { StreamEncoding::ListPacks4 },
                     >::init(buffer, input)?;
                     buffer.consume_to(input.as_ptr());
                     let item = self.set_entrust(entrust, buffer)?;

--- a/src/parser/record/stream.rs
+++ b/src/parser/record/stream.rs
@@ -27,6 +27,8 @@ pub struct StreamListPackRecordParser<const ENC: StreamEncoding> {
         StreamMetaParser<ENC>,
         StreamGroupsParser<ENC>,
     >,
+    idmp: StreamIdmpParser<ENC>,
+    message_count: Option<u64>,
 }
 
 impl<const ENC: StreamEncoding> InitializableParser for StreamListPackRecordParser<ENC> {
@@ -38,11 +40,14 @@ impl<const ENC: StreamEncoding> InitializableParser for StreamListPackRecordPars
             StreamMetaParser<ENC>,
             StreamGroupsParser<ENC>,
         > as InitializableParser>::init(buffer, input)?;
+        let (input, idmp) = StreamIdmpParser::<ENC>::init(buffer, input)?;
 
         Ok((input, Self {
             key,
             started: buffer.tell(),
             entrust,
+            idmp,
+            message_count: None,
         }))
     }
 }
@@ -51,14 +56,23 @@ impl<const ENC: StreamEncoding> StateParser for StreamListPackRecordParser<ENC> 
     type Output = Item;
 
     fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
-        let (_, message_count, _, _) = self.entrust.call(buffer)?;
+        if self.message_count.is_none() {
+            let (_, message_count, _, _) = self.entrust.call(buffer)?;
+            self.message_count = Some(
+                message_count
+                    .as_u64()
+                    .context("message count should be a number")?,
+            );
+        }
+        self.idmp.call(buffer)?;
         Ok(Item::StreamRecord {
             key: self.key.clone(),
             rdb_size: buffer.tell() - self.started,
             encoding: ENC,
-            message_count: message_count
-                .as_u64()
-                .context("message count should be a number")?,
+            message_count: self
+                .message_count
+                .take()
+                .context("stream message count should be parsed")?,
         })
     }
 }
@@ -69,10 +83,12 @@ struct EntriesReadParser<const ENC: StreamEncoding> {
 
 impl<const ENC: StreamEncoding> InitializableParser for EntriesReadParser<ENC> {
     fn init<'a>(buf: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
-        // `entries_read` field only exists in v2/v3, not in v1 (ListPacks).
+        // `entries_read` field only exists in v2+, not in v1 (ListPacks).
         match ENC {
             StreamEncoding::ListPacks => Ok((input, Self { inner: None })),
-            StreamEncoding::ListPacks2 | StreamEncoding::ListPacks3 => {
+            StreamEncoding::ListPacks2
+            | StreamEncoding::ListPacks3
+            | StreamEncoding::ListPacks4 => {
                 let (input, parser) = RDBLenParser::init(buf, input)?;
                 Ok((input, Self {
                     inner: Some(parser),
@@ -137,8 +153,8 @@ impl<const ENC: StreamEncoding> InitializableParser for ConsumerTimeParser<ENC> 
     fn init<'a>(_: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
         Ok((input, Self {
             remain: match ENC {
-                StreamEncoding::ListPacks3 => 16, // seen_time + active_time
-                StreamEncoding::ListPacks | StreamEncoding::ListPacks2 => 8, // only seen_time
+                StreamEncoding::ListPacks3 | StreamEncoding::ListPacks4 => 16, /* seen_time + active_time */
+                StreamEncoding::ListPacks | StreamEncoding::ListPacks2 => 8,   // only seen_time
             },
         }))
     }
@@ -249,7 +265,7 @@ impl<const ENC: StreamEncoding> InitializableParser for StreamMetaParser<ENC> {
         let remain = match ENC {
             StreamEncoding::ListPacks => 2,  // last_id.ms + last_id.seq
             StreamEncoding::ListPacks2 => 7, /* last_id + first_id + max_deleted_id (each 2 varints) */
-            StreamEncoding::ListPacks3 => 7, // v2 meta + entries_added
+            StreamEncoding::ListPacks3 | StreamEncoding::ListPacks4 => 7, // v2 meta + entries_added
         };
         let entrust: ReduceParser<RDBLenParser, ()> = ReduceParser::new(remain, (), |_, _| ());
         Ok((input, Self { entrust }))
@@ -288,6 +304,156 @@ impl<const ENC: StreamEncoding> StateParser for StreamGroupsParser<ENC> {
 
     fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
         self.entrust.call(buffer)?;
+        Ok(())
+    }
+}
+
+struct StreamIdmpEntryParser {
+    entrust: Seq3Parser<StringEncodingParser, RDBLenParser, RDBLenParser>,
+}
+
+fn ignore_unit(_: (), _: ()) {}
+
+impl InitializableParser for StreamIdmpEntryParser {
+    fn init<'a>(buffer: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        let (input, entrust) =
+            <Seq3Parser<StringEncodingParser, RDBLenParser, RDBLenParser> as InitializableParser>::init(
+                buffer, input,
+            )?;
+        Ok((input, Self { entrust }))
+    }
+}
+
+impl StateParser for StreamIdmpEntryParser {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        self.entrust.call(buffer)?;
+        Ok(())
+    }
+}
+
+struct StreamIdmpProducerParser {
+    producer_id: StringEncodingParser,
+    producer_id_done: bool,
+    entries: Option<ReduceParser<StreamIdmpEntryParser, ()>>,
+}
+
+impl InitializableParser for StreamIdmpProducerParser {
+    fn init<'a>(buffer: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        let (input, producer_id) = StringEncodingParser::init(buffer, input)?;
+        Ok((input, Self {
+            producer_id,
+            producer_id_done: false,
+            entries: None,
+        }))
+    }
+}
+
+impl StateParser for StreamIdmpProducerParser {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        if !self.producer_id_done {
+            self.producer_id.call(buffer)?;
+            self.producer_id_done = true;
+        }
+
+        if self.entries.is_none() {
+            let (input, entry_count) =
+                read_rdb_len(buffer.as_slice()).context("read stream IDMP entry count")?;
+            buffer.consume_to(input.as_ptr());
+            let entry_count = entry_count
+                .as_u64()
+                .context("stream IDMP entry count should be numeric")?;
+            self.entries = Some(ReduceParser::new(
+                entry_count,
+                (),
+                ignore_unit as fn((), ()),
+            ));
+        }
+
+        if let Some(ref mut entries) = self.entries {
+            entries.call(buffer)?;
+        }
+        Ok(())
+    }
+}
+
+struct StreamIdmpProducersParser {
+    producers: ReduceParser<StreamIdmpProducerParser, ()>,
+}
+
+impl InitializableParser for StreamIdmpProducersParser {
+    fn init<'a>(_: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        let (input, producer_count) =
+            read_rdb_len(input).context("read stream IDMP producer count")?;
+        let producer_count = producer_count
+            .as_u64()
+            .context("stream IDMP producer count should be numeric")?;
+        Ok((input, Self {
+            producers: ReduceParser::new(producer_count, (), ignore_unit as fn((), ())),
+        }))
+    }
+}
+
+impl StateParser for StreamIdmpProducersParser {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        self.producers.call(buffer)?;
+        Ok(())
+    }
+}
+
+struct StreamIdmpParser<const ENC: StreamEncoding> {
+    enabled: bool,
+    entrust: Option<
+        Seq5Parser<
+            RDBLenParser,
+            RDBLenParser,
+            StreamIdmpProducersParser,
+            RDBLenParser,
+            RDBLenParser,
+        >,
+    >,
+}
+
+impl<const ENC: StreamEncoding> InitializableParser for StreamIdmpParser<ENC> {
+    fn init<'a>(_: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        Ok((input, Self {
+            enabled: ENC == StreamEncoding::ListPacks4,
+            entrust: None,
+        }))
+    }
+}
+
+impl<const ENC: StreamEncoding> StateParser for StreamIdmpParser<ENC> {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        if self.entrust.is_none() {
+            let (input, entrust) =
+                <Seq5Parser<
+                    RDBLenParser,
+                    RDBLenParser,
+                    StreamIdmpProducersParser,
+                    RDBLenParser,
+                    RDBLenParser,
+                > as InitializableParser>::init(buffer, buffer.as_slice())?;
+            buffer.consume_to(input.as_ptr());
+            self.entrust = Some(entrust);
+        }
+
+        if let Some(ref mut entrust) = self.entrust {
+            entrust.call(buffer)?;
+        }
+        self.entrust = None;
+        self.enabled = false;
         Ok(())
     }
 }

--- a/tests/common/setup.rs
+++ b/tests/common/setup.rs
@@ -18,6 +18,7 @@ const LOG_OUTPUT_LIMIT: usize = 4_096;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RedisVariant {
+    Redis8_6,
     Redis8_0,
     Redis7_0,
     Redis6_0,
@@ -34,6 +35,7 @@ impl RedisVariant {
             RedisVariant::StackLatest => {
                 ("redis/redis-stack-server".to_string(), "latest".to_string())
             }
+            RedisVariant::Redis8_6 => (repo, "8.6.4".to_string()),
             RedisVariant::Redis8_0 => (repo, "8.0.5".to_string()),
             RedisVariant::Redis7_0 => (repo, "7.0.15".to_string()),
             RedisVariant::Redis6_0 => (repo, "6.0.20".to_string()),
@@ -43,7 +45,8 @@ impl RedisVariant {
 
     fn server_command(&self) -> &'static str {
         match self {
-            RedisVariant::Redis8_0
+            RedisVariant::Redis8_6
+            | RedisVariant::Redis8_0
             | RedisVariant::Redis7_0
             | RedisVariant::Redis6_0
             | RedisVariant::Redis2_8 => "redis-server",

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1668,12 +1668,19 @@ async fn stream_v3_listpack_test() -> AnyResult<()> {
     run_stream_listpack_test("8.0", StreamEncoding::ListPacks3).await
 }
 
+#[tokio::test]
+async fn stream_v4_listpack_test() -> AnyResult<()> {
+    run_stream_listpack_test("8.6", StreamEncoding::ListPacks4).await
+}
+
 async fn run_stream_listpack_test(version: &str, expect_encoding: StreamEncoding) -> AnyResult<()> {
     use common::{create_stream_groups, seed_stream};
     const MESSAGE_COUNT: usize = 500;
+    const IDMP_MESSAGE_COUNT: usize = 4;
 
     let redis = RedisConfig::default()
         .with_version(match version {
+            "8.6" => RedisVariant::Redis8_6,
             "6.0" => RedisVariant::Redis6_0,
             "7.0" => RedisVariant::Redis7_0,
             "8.0" => RedisVariant::Redis8_0,
@@ -1688,6 +1695,33 @@ async fn run_stream_listpack_test(version: &str, expect_encoding: StreamEncoding
             |conn| {
                 async move {
                     seed_stream(conn, "mystream", MESSAGE_COUNT).await?;
+                    if expect_encoding == StreamEncoding::ListPacks4 {
+                        for producer_idx in 0..2 {
+                            for iid_idx in 0..2 {
+                                let _: redis::Value = redis::cmd("XADD")
+                                    .arg("mystream")
+                                    .arg("IDMP")
+                                    .arg(format!("producer-{producer_idx}"))
+                                    .arg(format!("iid-{producer_idx}-{iid_idx}"))
+                                    .arg("*")
+                                    .arg("field")
+                                    .arg(format!("value-{producer_idx}-{iid_idx}"))
+                                    .query_async(conn)
+                                    .await?;
+                            }
+                        }
+
+                        let _: redis::Value = redis::cmd("XADD")
+                            .arg("mystream")
+                            .arg("IDMP")
+                            .arg("producer-0")
+                            .arg("iid-0-0")
+                            .arg("*")
+                            .arg("field")
+                            .arg("duplicate")
+                            .query_async(conn)
+                            .await?;
+                    }
 
                     let groups = ["cg_alpha", "cg_beta", "cg_gamma"];
                     create_stream_groups(conn, "mystream", &groups).await?;
@@ -1727,7 +1761,15 @@ async fn run_stream_listpack_test(version: &str, expect_encoding: StreamEncoding
         panic!("expected StreamRecord");
     };
     assert_eq!(*key, RDBStr::Str(Bytes::from("mystream")));
-    assert_eq!(*message_count as usize, MESSAGE_COUNT);
+    assert_eq!(
+        *message_count as usize,
+        MESSAGE_COUNT
+            + if expect_encoding == StreamEncoding::ListPacks4 {
+                IDMP_MESSAGE_COUNT
+            } else {
+                0
+            }
+    );
     assert_eq!(*encoding, expect_encoding);
 
     Ok(())


### PR DESCRIPTION
## Why

Redis 8.6 writes streams with RDB version 13 and `RDB_TYPE_STREAM_LISTPACKS_4`. That encoding adds IDMP metadata after the existing stream consumer group payload, so the parser needs to recognize the new type and consume the additional stream tail.

## What

- Accept RDB version 13 and map `RDB_TYPE_STREAM_LISTPACKS_4` to `StreamEncoding::ListPacks4`.
- Parse the Redis 8.6 stream IDMP tail, including non-empty producer/IID entries, while keeping the existing stream record summary behavior.
- Add a Redis 8.6.4 integration variant and extend the Redis test-image publishing matrix to build `8.6.4`.
- Strengthen the stream integration test to cover Redis 6.0, 7.0, 8.0, and 8.6, with the 8.6 case exercising IDMP and duplicate IID metadata.
