### PR TITLE
feat(redis): parse Redis 8.8 RDB records

### DIFF
--- a/.github/workflows/publish-test-images.yml
+++ b/.github/workflows/publish-test-images.yml
@@ -3,6 +3,11 @@ name: Publish Redis Test Images
 # NOTE: This workflow is intentionally manual-only to avoid automatic image publishing.
 on:
   workflow_dispatch:
+    inputs:
+      redis_versions:
+        description: 'Redis versions to publish as a JSON array, for example: ["8.8.0"]'
+        required: false
+        default: '["8.8.0", "8.6.4", "8.0.5", "7.0.15", "6.0.20", "2.8.24"]'
 
 permissions:
   contents: read
@@ -14,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ["8.6.4", "8.0.5", "7.0.15", "6.0.20", "2.8.24"]
+        redis: ${{ fromJSON(inputs.redis_versions) }}
         platform: [amd64, arm64]
         include:
           - platform: amd64
@@ -74,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redis: ["8.6.4", "8.0.5", "7.0.15", "6.0.20", "2.8.24"]
+        redis: ${{ fromJSON(inputs.redis_versions) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,7 @@ serde_with = { version = "3.15.1", features = ["base64"] }
 shadow-rs = "2.0.0"
 spire_enum = "1.0.0"
 thiserror = "2.0.17"
-time = { version = "0.3.44", features = [
-    "formatting",
-    "parsing",
-    "macros",
-    "large-dates",
-] }
+time = { version = "0.3.47", features = ["formatting", "parsing", "macros", "large-dates"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.16", features = ["time"] }
 tower-service = "0.3.3"

--- a/src/parser/model.rs
+++ b/src/parser/model.rs
@@ -34,6 +34,11 @@ pub enum Item {
         encoding: ListEncoding,
         member_count: u64,
     },
+    ArrayRecord {
+        key: RDBStr,
+        rdb_size: u64,
+        member_count: u64,
+    },
     SetRecord {
         key: RDBStr,
         /// Size of the record in bytes.
@@ -218,6 +223,7 @@ pub enum StreamEncoding {
     ListPacks2,
     ListPacks3,
     ListPacks4,
+    ListPacks5,
 }
 
 /// Opcode of RDB, ref: https://github.com/redis/redis/blob/2ba81b70957691a6a010e785225672e6657e53e8/src/rdb.h#L93
@@ -268,6 +274,8 @@ pub enum RDBType {
     HashMetadata = 24,        // RDB_TYPE_HASH_METADATA
     HashListPackEx = 25,      // RDB_TYPE_HASH_LISTPACK_EX
     StreamListPacks4 = 26,    // RDB_TYPE_STREAM_LISTPACKS_4
+    StreamListPacks5 = 27,    // RDB_TYPE_STREAM_LISTPACKS_5
+    Array = 28,               // RDB_TYPE_ARRAY
 }
 
 /// Module serialized values sub opcodes, ref: https://github.com/redis/redis/blob/2ba81b70957691a6a010e785225672e6657e53e8/src/rdb.h#L133

--- a/src/parser/rdb_file.rs
+++ b/src/parser/rdb_file.rs
@@ -12,6 +12,7 @@ use crate::{
         },
         model::{Item, RDBOpcode, RDBType, StreamEncoding},
         record::{
+            array::ArrayRecordParser,
             function::Function2RecordParser,
             hash::{
                 HashListPackExRecordParser, HashListPackRecordParser, HashMetadataRecordParser,
@@ -41,10 +42,12 @@ enum ItemParser {
     ListZipList(ListZipListRecordParser),
     ListQuickList(ListQuickListRecordParser),
     ListQuickList2(ListQuickList2RecordParser),
+    Array(ArrayRecordParser),
     StreamListPack(StreamListPackRecordParser<{ StreamEncoding::ListPacks }>),
     StreamListPack2(StreamListPackRecordParser<{ StreamEncoding::ListPacks2 }>),
     StreamListPack3(StreamListPackRecordParser<{ StreamEncoding::ListPacks3 }>),
     StreamListPack4(StreamListPackRecordParser<{ StreamEncoding::ListPacks4 }>),
+    StreamListPack5(StreamListPackRecordParser<{ StreamEncoding::ListPacks5 }>),
     Set(SetRecordParser),
     SetIntSet(SetIntSetRecordParser),
     SetListPack(SetListPackRecordParser),
@@ -88,7 +91,7 @@ impl RDBFileParser {
         let version = std::str::from_utf8(version).context("version should be utf8")?;
         let version: u64 = version.parse().context("version should be a number")?;
         ensure!(version >= 1, "version should be >= 1");
-        ensure!(version <= 13, "version should be <= 13");
+        ensure!(version <= 14, "version should be <= 14");
 
         self.version = version;
         buffer.consume_to(input.as_ptr());
@@ -281,6 +284,12 @@ impl RDBFileParser {
                     let item = self.set_entrust(entrust, buffer)?;
                     self.return_item(item)
                 }
+                RDBType::Array => {
+                    let (input, entrust) = ArrayRecordParser::init(buffer, input)?;
+                    buffer.consume_to(input.as_ptr());
+                    let item = self.set_entrust(entrust, buffer)?;
+                    self.return_item(item)
+                }
                 RDBType::Set => {
                     let (input, entrust) = SetRecordParser::init(buffer, input)?;
                     buffer.consume_to(input.as_ptr());
@@ -387,6 +396,14 @@ impl RDBFileParser {
                 RDBType::StreamListPacks4 => {
                     let (input, entrust) = StreamListPackRecordParser::<
                         { StreamEncoding::ListPacks4 },
+                    >::init(buffer, input)?;
+                    buffer.consume_to(input.as_ptr());
+                    let item = self.set_entrust(entrust, buffer)?;
+                    self.return_item(item)
+                }
+                RDBType::StreamListPacks5 => {
+                    let (input, entrust) = StreamListPackRecordParser::<
+                        { StreamEncoding::ListPacks5 },
                     >::init(buffer, input)?;
                     buffer.consume_to(input.as_ptr());
                     let item = self.set_entrust(entrust, buffer)?;

--- a/src/parser/record/array.rs
+++ b/src/parser/record/array.rs
@@ -1,0 +1,169 @@
+use anyhow::{Context, bail};
+
+use crate::{
+    helper::AnyResult,
+    parser::{
+        core::{
+            buffer::{Buffer, skip_bytes},
+            raw::{RDBLen, RDBStr, read_rdb_len, read_rdb_str},
+        },
+        model::Item,
+        record::string::StringEncodingParser,
+        state::traits::{InitializableParser, StateParser},
+    },
+};
+
+const AR_RDB_TAG_SDS: u64 = 0;
+const AR_RDB_TAG_INT: u64 = 1;
+const AR_RDB_TAG_FLOAT: u64 = 2;
+const AR_RDB_TAG_SMALLSTR: u64 = 3;
+
+pub struct ArrayRecordParser {
+    started: u64,
+    key: RDBStr,
+    member_count: u64,
+    entries: ArrayEntriesParser,
+}
+
+impl InitializableParser for ArrayRecordParser {
+    fn init<'a>(buffer: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        let (input, key) = read_rdb_str(input).context("read array key")?;
+        let (input, member_count) = read_rdb_len(input).context("read array element count")?;
+        let member_count = member_count
+            .as_u64()
+            .context("array element count should be numeric")?;
+
+        let (input, insert_idx_flag) =
+            read_rdb_len(input).context("read array insert index flag")?;
+        match insert_idx_flag
+            .as_u64()
+            .context("array insert index flag should be numeric")?
+        {
+            0 => {}
+            1 => {
+                let (next, _) = read_rdb_len(input).context("read array insert index")?;
+                return Ok((next, Self {
+                    started: buffer.tell(),
+                    key,
+                    member_count,
+                    entries: ArrayEntriesParser::new(member_count),
+                }));
+            }
+            other => bail!("invalid array insert index flag: {other}"),
+        }
+
+        Ok((input, Self {
+            started: buffer.tell(),
+            key,
+            member_count,
+            entries: ArrayEntriesParser::new(member_count),
+        }))
+    }
+}
+
+impl StateParser for ArrayRecordParser {
+    type Output = Item;
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        self.entries.call(buffer)?;
+        Ok(Item::ArrayRecord {
+            key: self.key.clone(),
+            rdb_size: buffer.tell() - self.started,
+            member_count: self.member_count,
+        })
+    }
+}
+
+struct ArrayEntriesParser {
+    remain: u64,
+    entry: Option<ArrayElementParser>,
+}
+
+impl ArrayEntriesParser {
+    fn new(remain: u64) -> Self {
+        Self {
+            remain,
+            entry: None,
+        }
+    }
+}
+
+impl StateParser for ArrayEntriesParser {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        loop {
+            if let Some(entry) = self.entry.as_mut() {
+                entry.call(buffer)?;
+                self.entry = None;
+                self.remain -= 1;
+            }
+
+            if self.remain == 0 {
+                return Ok(());
+            }
+
+            let (input, entry) = ArrayElementParser::init(buffer, buffer.as_slice())?;
+            buffer.consume_to(input.as_ptr());
+            self.entry = Some(entry);
+        }
+    }
+}
+
+enum ArrayElementValueParser {
+    Skip { remain: u64 },
+    String(StringEncodingParser),
+}
+
+impl StateParser for ArrayElementValueParser {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        match self {
+            Self::Skip { remain } => skip_bytes(buffer, remain),
+            Self::String(parser) => {
+                parser.call(buffer)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+struct ArrayElementParser {
+    value: ArrayElementValueParser,
+}
+
+impl InitializableParser for ArrayElementParser {
+    fn init<'a>(buffer: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        let (input, index) = read_rdb_len(input).context("read array element index")?;
+        if !matches!(index, RDBLen::Simple(_)) {
+            bail!("array element index should be a plain length");
+        }
+
+        let (input, tag) = read_rdb_len(input).context("read array element type tag")?;
+        let tag = tag
+            .as_u64()
+            .context("array element type tag should be numeric")?;
+
+        let (input, value) = match tag {
+            AR_RDB_TAG_INT | AR_RDB_TAG_FLOAT => {
+                (input, ArrayElementValueParser::Skip { remain: 8 })
+            }
+            AR_RDB_TAG_SMALLSTR | AR_RDB_TAG_SDS => {
+                let (input, parser) = StringEncodingParser::init(buffer, input)?;
+                (input, ArrayElementValueParser::String(parser))
+            }
+            other => bail!("unknown array element type tag: {other}"),
+        };
+
+        Ok((input, Self { value }))
+    }
+}
+
+impl StateParser for ArrayElementParser {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        self.value.call(buffer)
+    }
+}

--- a/src/parser/record/mod.rs
+++ b/src/parser/record/mod.rs
@@ -1,3 +1,4 @@
+pub mod array;
 pub mod function;
 pub mod hash;
 pub mod list;

--- a/src/parser/record/stream.rs
+++ b/src/parser/record/stream.rs
@@ -88,7 +88,8 @@ impl<const ENC: StreamEncoding> InitializableParser for EntriesReadParser<ENC> {
             StreamEncoding::ListPacks => Ok((input, Self { inner: None })),
             StreamEncoding::ListPacks2
             | StreamEncoding::ListPacks3
-            | StreamEncoding::ListPacks4 => {
+            | StreamEncoding::ListPacks4
+            | StreamEncoding::ListPacks5 => {
                 let (input, parser) = RDBLenParser::init(buf, input)?;
                 Ok((input, Self {
                     inner: Some(parser),
@@ -136,13 +137,48 @@ impl<const ENC: StreamEncoding> StateParser for StreamConsumersParser<ENC> {
     }
 }
 
-type StreamGroupParser<const ENC: StreamEncoding> = Seq5Parser<
-    StringEncodingParser,
-    Seq2Parser<RDBLenParser, RDBLenParser>,
-    EntriesReadParser<ENC>,
-    StreamPELParser<true>,
-    StreamConsumersParser<ENC>,
->;
+struct StreamGroupParser<const ENC: StreamEncoding> {
+    entrust: Seq5Parser<
+        StringEncodingParser,
+        Seq2Parser<RDBLenParser, RDBLenParser>,
+        EntriesReadParser<ENC>,
+        StreamPELParser<true>,
+        StreamConsumersParser<ENC>,
+    >,
+    entrust_done: bool,
+    nacks: StreamNackZoneParser<ENC>,
+}
+
+impl<const ENC: StreamEncoding> InitializableParser for StreamGroupParser<ENC> {
+    fn init<'a>(buffer: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        let (input, entrust) = <Seq5Parser<
+            StringEncodingParser,
+            Seq2Parser<RDBLenParser, RDBLenParser>,
+            EntriesReadParser<ENC>,
+            StreamPELParser<true>,
+            StreamConsumersParser<ENC>,
+        > as InitializableParser>::init(buffer, input)?;
+        let (input, nacks) = StreamNackZoneParser::<ENC>::init(buffer, input)?;
+        Ok((input, Self {
+            entrust,
+            entrust_done: false,
+            nacks,
+        }))
+    }
+}
+
+impl<const ENC: StreamEncoding> StateParser for StreamGroupParser<ENC> {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        if !self.entrust_done {
+            self.entrust.call(buffer)?;
+            self.entrust_done = true;
+        }
+        self.nacks.call(buffer)?;
+        Ok(())
+    }
+}
 
 // helper parser that skips seen_time(8 bytes) and optionally active_time(8 bytes)
 struct ConsumerTimeParser<const ENC: StreamEncoding> {
@@ -153,8 +189,10 @@ impl<const ENC: StreamEncoding> InitializableParser for ConsumerTimeParser<ENC> 
     fn init<'a>(_: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
         Ok((input, Self {
             remain: match ENC {
-                StreamEncoding::ListPacks3 | StreamEncoding::ListPacks4 => 16, /* seen_time + active_time */
-                StreamEncoding::ListPacks | StreamEncoding::ListPacks2 => 8,   // only seen_time
+                StreamEncoding::ListPacks3
+                | StreamEncoding::ListPacks4
+                | StreamEncoding::ListPacks5 => 16, // seen_time + active_time
+                StreamEncoding::ListPacks | StreamEncoding::ListPacks2 => 8, // only seen_time
             },
         }))
     }
@@ -229,6 +267,66 @@ impl<const WITH_NACK: bool> StateParser for PELEntryParser<WITH_NACK> {
     }
 }
 
+struct StreamNackZoneParser<const ENC: StreamEncoding> {
+    enabled: bool,
+    entries: Option<ReduceParser<StreamIdParser, ()>>,
+}
+
+impl<const ENC: StreamEncoding> InitializableParser for StreamNackZoneParser<ENC> {
+    fn init<'a>(_: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        Ok((input, Self {
+            enabled: ENC == StreamEncoding::ListPacks5,
+            entries: None,
+        }))
+    }
+}
+
+impl<const ENC: StreamEncoding> StateParser for StreamNackZoneParser<ENC> {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        if self.entries.is_none() {
+            let (input, count) =
+                read_rdb_len(buffer.as_slice()).context("read stream NACK zone count")?;
+            buffer.consume_to(input.as_ptr());
+            let count = count
+                .as_u64()
+                .context("stream NACK zone count should be numeric")?;
+            self.entries = Some(ReduceParser::new(count, (), ignore_unit as fn((), ())));
+        }
+
+        if let Some(ref mut entries) = self.entries {
+            entries.call(buffer)?;
+        }
+        self.entries = None;
+        self.enabled = false;
+        Ok(())
+    }
+}
+
+struct StreamIdParser {
+    remain: u64,
+}
+
+impl InitializableParser for StreamIdParser {
+    fn init<'a>(_: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
+        Ok((input, Self { remain: 16 }))
+    }
+}
+
+impl StateParser for StreamIdParser {
+    type Output = ();
+
+    fn call(&mut self, buffer: &mut Buffer) -> AnyResult<Self::Output> {
+        skip_bytes(buffer, &mut self.remain)?;
+        Ok(())
+    }
+}
+
 struct ListPackEntriesParser {
     entrust: ReduceParser<StringEncodingParser, ()>,
 }
@@ -265,7 +363,9 @@ impl<const ENC: StreamEncoding> InitializableParser for StreamMetaParser<ENC> {
         let remain = match ENC {
             StreamEncoding::ListPacks => 2,  // last_id.ms + last_id.seq
             StreamEncoding::ListPacks2 => 7, /* last_id + first_id + max_deleted_id (each 2 varints) */
-            StreamEncoding::ListPacks3 | StreamEncoding::ListPacks4 => 7, // v2 meta + entries_added
+            StreamEncoding::ListPacks3
+            | StreamEncoding::ListPacks4
+            | StreamEncoding::ListPacks5 => 7, // v2 meta + entries_added
         };
         let entrust: ReduceParser<RDBLenParser, ()> = ReduceParser::new(remain, (), |_, _| ());
         Ok((input, Self { entrust }))
@@ -422,7 +522,7 @@ struct StreamIdmpParser<const ENC: StreamEncoding> {
 impl<const ENC: StreamEncoding> InitializableParser for StreamIdmpParser<ENC> {
     fn init<'a>(_: &Buffer, input: &'a [u8]) -> AnyResult<(&'a [u8], Self)> {
         Ok((input, Self {
-            enabled: ENC == StreamEncoding::ListPacks4,
+            enabled: ENC == StreamEncoding::ListPacks4 || ENC == StreamEncoding::ListPacks5,
             entrust: None,
         }))
     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -39,6 +39,7 @@ use crate::{
 pub enum RecordType {
     String,
     List,
+    Array,
     Set,
     ZSet,
     Hash,
@@ -51,6 +52,7 @@ impl RecordType {
         match self {
             RecordType::String => "string",
             RecordType::List => "list",
+            RecordType::Array => "array",
             RecordType::Set => "set",
             RecordType::ZSet => "zset",
             RecordType::Hash => "hash",
@@ -76,6 +78,7 @@ impl RecordType {
 pub enum RecordEncoding {
     String(StringEncoding),
     List(ListEncoding),
+    Array,
     Set(SetEncoding),
     ZSet(ZSetEncoding),
     Hash(HashEncoding),
@@ -141,6 +144,7 @@ impl Record {
         match self.encoding {
             RecordEncoding::String(enc) => enc.to_string(),
             RecordEncoding::List(enc) => enc.to_string(),
+            RecordEncoding::Array => "array".to_string(),
             RecordEncoding::Set(enc) => enc.to_string(),
             RecordEncoding::ZSet(enc) => enc.to_string(),
             RecordEncoding::Hash(enc) => enc.to_string(),
@@ -294,6 +298,28 @@ impl RecordStream {
                         .key(key)
                         .r#type(RecordType::List)
                         .encoding(RecordEncoding::List(encoding))
+                        .rdb_size(rdb_size)
+                        .member_count(Some(member_count))
+                        .expire_at_ms(self.pending_expiry.take())
+                        .idle_seconds(self.pending_idle.take())
+                        .freq(self.pending_freq.take())
+                        .codis_slot(codis_slot)
+                        .redis_slot(redis_slot)
+                        .build(),
+                )
+            }
+            Item::ArrayRecord {
+                key,
+                member_count,
+                rdb_size,
+            } => {
+                let (codis_slot, redis_slot) = self.calculate_slot(&key);
+                Some(
+                    Record::builder()
+                        .db(self.current_db)
+                        .key(key)
+                        .r#type(RecordType::Array)
+                        .encoding(RecordEncoding::Array)
                         .rdb_size(rdb_size)
                         .member_count(Some(member_count))
                         .expire_at_ms(self.pending_expiry.take())

--- a/tests/common/setup.rs
+++ b/tests/common/setup.rs
@@ -18,6 +18,7 @@ const LOG_OUTPUT_LIMIT: usize = 4_096;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RedisVariant {
+    Redis8_8,
     Redis8_6,
     Redis8_0,
     Redis7_0,
@@ -35,6 +36,7 @@ impl RedisVariant {
             RedisVariant::StackLatest => {
                 ("redis/redis-stack-server".to_string(), "latest".to_string())
             }
+            RedisVariant::Redis8_8 => (repo, "8.8.0".to_string()),
             RedisVariant::Redis8_6 => (repo, "8.6.4".to_string()),
             RedisVariant::Redis8_0 => (repo, "8.0.5".to_string()),
             RedisVariant::Redis7_0 => (repo, "7.0.15".to_string()),
@@ -45,7 +47,8 @@ impl RedisVariant {
 
     fn server_command(&self) -> &'static str {
         match self {
-            RedisVariant::Redis8_6
+            RedisVariant::Redis8_8
+            | RedisVariant::Redis8_6
             | RedisVariant::Redis8_0
             | RedisVariant::Redis7_0
             | RedisVariant::Redis6_0

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1654,6 +1654,77 @@ async fn zset_listpack_lzf_encoding_test() -> AnyResult<()> {
 }
 
 #[tokio::test]
+async fn array_encoding_test() -> AnyResult<()> {
+    let redis = RedisConfig::default()
+        .with_version(RedisVariant::Redis8_8)
+        .build()
+        .await?;
+
+    let rdb_path = redis
+        .generate_rdb("array_encoding_test", |conn| {
+            async move {
+                redis::cmd("ARMSET")
+                    .arg("array_dense")
+                    .arg(0)
+                    .arg("zero")
+                    .arg(1)
+                    .arg("1")
+                    .arg(2)
+                    .arg(std::f64::consts::PI.to_string())
+                    .query_async::<()>(conn)
+                    .await?;
+
+                redis::cmd("ARMSET")
+                    .arg("array_sparse")
+                    .arg(0)
+                    .arg("head")
+                    .arg(4096)
+                    .arg("slice-boundary")
+                    .arg(99_999)
+                    .arg("tail")
+                    .query_async::<()>(conn)
+                    .await?;
+
+                redis::cmd("ARRING")
+                    .arg("array_ring")
+                    .arg(3)
+                    .arg("a")
+                    .arg("b")
+                    .arg("c")
+                    .arg("d")
+                    .query_async::<()>(conn)
+                    .await?;
+
+                Ok(())
+            }
+            .boxed()
+        })
+        .await?;
+
+    let mut arrays = read_filtered_items(&rdb_path)
+        .await?
+        .into_iter()
+        .map(|item| {
+            let Item::ArrayRecord {
+                key, member_count, ..
+            } = item
+            else {
+                panic!("expected ArrayRecord");
+            };
+            (key, member_count)
+        })
+        .collect::<Vec<_>>();
+    arrays.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    assert_eq!(arrays.len(), 3);
+    assert_eq!(arrays[0], (RDBStr::Str(Bytes::from("array_dense")), 3));
+    assert_eq!(arrays[1], (RDBStr::Str(Bytes::from("array_ring")), 3));
+    assert_eq!(arrays[2], (RDBStr::Str(Bytes::from("array_sparse")), 3));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn stream_v1_listpack_test() -> AnyResult<()> {
     run_stream_listpack_test("6.0", StreamEncoding::ListPacks).await
 }
@@ -1673,13 +1744,20 @@ async fn stream_v4_listpack_test() -> AnyResult<()> {
     run_stream_listpack_test("8.6", StreamEncoding::ListPacks4).await
 }
 
+#[tokio::test]
+async fn stream_v5_listpack_test() -> AnyResult<()> {
+    run_stream_listpack_test("8.8", StreamEncoding::ListPacks5).await
+}
+
 async fn run_stream_listpack_test(version: &str, expect_encoding: StreamEncoding) -> AnyResult<()> {
     use common::{create_stream_groups, seed_stream};
     const MESSAGE_COUNT: usize = 500;
     const IDMP_MESSAGE_COUNT: usize = 4;
+    const XNACK_MESSAGE_COUNT: usize = 1;
 
     let redis = RedisConfig::default()
         .with_version(match version {
+            "8.8" => RedisVariant::Redis8_8,
             "8.6" => RedisVariant::Redis8_6,
             "6.0" => RedisVariant::Redis6_0,
             "7.0" => RedisVariant::Redis7_0,
@@ -1695,7 +1773,10 @@ async fn run_stream_listpack_test(version: &str, expect_encoding: StreamEncoding
             |conn| {
                 async move {
                     seed_stream(conn, "mystream", MESSAGE_COUNT).await?;
-                    if expect_encoding == StreamEncoding::ListPacks4 {
+                    if matches!(
+                        expect_encoding,
+                        StreamEncoding::ListPacks4 | StreamEncoding::ListPacks5
+                    ) {
                         for producer_idx in 0..2 {
                             for iid_idx in 0..2 {
                                 let _: redis::Value = redis::cmd("XADD")
@@ -1741,6 +1822,48 @@ async fn run_stream_listpack_test(version: &str, expect_encoding: StreamEncoding
                             .await?;
                     }
 
+                    if expect_encoding == StreamEncoding::ListPacks5 {
+                        redis::cmd("XGROUP")
+                            .arg("CREATE")
+                            .arg("mystream")
+                            .arg("cg_nack")
+                            .arg("$")
+                            .query_async::<()>(conn)
+                            .await?;
+
+                        let nacked_id: String = redis::cmd("XADD")
+                            .arg("mystream")
+                            .arg("*")
+                            .arg("field")
+                            .arg("nack")
+                            .query_async(conn)
+                            .await?;
+
+                        let _: redis::Value = redis::cmd("XREADGROUP")
+                            .arg("GROUP")
+                            .arg("cg_nack")
+                            .arg("c_nack")
+                            .arg("COUNT")
+                            .arg(1)
+                            .arg("STREAMS")
+                            .arg("mystream")
+                            .arg(">")
+                            .query_async(conn)
+                            .await?;
+
+                        redis::cmd("XNACK")
+                            .arg("mystream")
+                            .arg("cg_nack")
+                            .arg("SILENT")
+                            .arg("IDS")
+                            .arg(1)
+                            .arg(nacked_id)
+                            .arg("RETRYCOUNT")
+                            .arg(2)
+                            .query_async::<()>(conn)
+                            .await?;
+                    }
+
                     Ok(())
                 }
                 .boxed()
@@ -1764,8 +1887,16 @@ async fn run_stream_listpack_test(version: &str, expect_encoding: StreamEncoding
     assert_eq!(
         *message_count as usize,
         MESSAGE_COUNT
-            + if expect_encoding == StreamEncoding::ListPacks4 {
+            + if matches!(
+                expect_encoding,
+                StreamEncoding::ListPacks4 | StreamEncoding::ListPacks5
+            ) {
                 IDMP_MESSAGE_COUNT
+            } else {
+                0
+            }
+            + if expect_encoding == StreamEncoding::ListPacks5 {
+                XNACK_MESSAGE_COUNT
             } else {
                 0
             }

--- a/tests/record_test.rs
+++ b/tests/record_test.rs
@@ -94,6 +94,63 @@ async fn test_record_stream_integration() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_record_stream_array_output() -> Result<()> {
+    let redis_instance = RedisConfig::default()
+        .with_version(RedisVariant::Redis8_8)
+        .build()
+        .await?;
+
+    let client = redis::Client::open(redis_instance.connection_string.as_str())?;
+    let mut conn = client.get_multiplexed_async_connection().await?;
+
+    redis::cmd("ARMSET")
+        .arg("array_public_key")
+        .arg(0)
+        .arg("zero")
+        .arg(16)
+        .arg("sixteen")
+        .arg(1024)
+        .arg("tail")
+        .query_async::<()>(&mut conn)
+        .await?;
+
+    let host = redis_instance.container.get_host().await?;
+    let port = redis_instance.container.get_host_port_ipv4(6379).await?;
+    let address = format!("{}:{}", host, port);
+    let standalone_config = StandaloneConfig::new(address, String::new(), None);
+
+    let mut streams = standalone_config.get_rdb_streams().await?;
+    assert_eq!(streams.len(), 1, "Expected exactly one RDB stream");
+    let mut stream = streams.remove(0);
+    stream.as_mut().prepare().await?;
+
+    let mut record_stream =
+        RecordStream::new(Box::pin(stream), rdbinsight::source::SourceType::File);
+
+    let mut array_record = None;
+    while let Some(record) = record_stream.next().await {
+        let record = record?;
+        if record.key == RDBStr::Str("array_public_key".into()) {
+            array_record = Some(record);
+            break;
+        }
+    }
+
+    let record = array_record.ok_or_else(|| anyhow!("array_public_key record not found"))?;
+    assert_eq!(record.r#type, RecordType::Array);
+    assert_eq!(record.type_name(), "array");
+    assert_eq!(record.encoding, RecordEncoding::Array);
+    assert_eq!(record.encoding_name(), "array");
+    assert_eq!(record.member_count, Some(3));
+    assert!(
+        record.rdb_size > 0,
+        "array record should report a positive RDB size"
+    );
+
+    Ok(())
+}
+
 async fn populate_test_data(
     conn: &mut redis::aio::MultiplexedConnection,
 ) -> Result<Vec<ExpectedRecord>> {


### PR DESCRIPTION
## Why

Redis 8.8 writes RDB version 14 and introduces encodings that rdbinsight could not parse or expose correctly.

## What

- Add Redis 8.8 `ARRAY` RDB parsing and expose it as `array` records.
- Add stream listpack v5 parsing, including the per-group `XNACK` zone and IDMP tail handling.
- Add Redis 8.8 integration coverage for parser and `RecordStream` output paths.
- Let the manual Redis test-image publishing workflow accept a targeted version list, with Redis 8.8 included by default.
- Bump the direct `time` dependency requirement to `0.3.47`.

## Notes

This adds `RecordType::Array` and `RecordEncoding::Array` public enum variants so Redis 8.8 array records are represented explicitly.
