### PR TITLE
ci: add mixed parser benchmark reporting

### DIFF
--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import * as core from "@actions/core";
+import * as exec from "@actions/exec";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const BASE_OUTPUT = "parser-benchmark-base.txt";
+const CURRENT_OUTPUT = "parser-benchmark-current.txt";
+
+function repoPath(...segments) {
+  return path.join(process.env.GITHUB_WORKSPACE || process.cwd(), ...segments);
+}
+
+function fileExists(filePath) {
+  return fs.existsSync(filePath);
+}
+
+function envWith(overrides) {
+  return {
+    ...process.env,
+    ...overrides,
+  };
+}
+
+function quoteCommand(command, args) {
+  return [command, ...args].join(" ");
+}
+
+async function run(command, args, options = {}) {
+  const cwd = options.cwd || repoPath();
+  const outputPath = options.outputPath;
+  const output = outputPath ? fs.createWriteStream(outputPath) : null;
+
+  core.info(`$ ${quoteCommand(command, args)}`);
+
+  try {
+    const exitCode = await exec.exec(command, args, {
+      cwd,
+      env: options.env || process.env,
+      ignoreReturnCode: true,
+      listeners: {
+        stdout: (chunk) => output?.write(chunk),
+        stderr: (chunk) => output?.write(chunk),
+      },
+    });
+    if (exitCode !== 0) {
+      throw new Error(`${quoteCommand(command, args)} exited with code ${exitCode}`);
+    }
+  } finally {
+    await new Promise((resolve) => {
+      if (output) {
+        output.end(resolve);
+      } else {
+        resolve();
+      }
+    });
+  }
+}
+
+async function benchmarkBase() {
+  const baseSha = process.env.BASE_SHA;
+  if (process.env.GITHUB_EVENT_NAME !== "pull_request" || !baseSha) {
+    return false;
+  }
+
+  const worktree = path.join(os.tmpdir(), `rdbinsight-base-${process.env.GITHUB_RUN_ID}`);
+  await run("git", ["worktree", "add", worktree, baseSha]);
+
+  if (!fileExists(path.join(worktree, "benches", "parser.rs"))) {
+    fs.writeFileSync(BASE_OUTPUT, "Base branch has no parser benchmark; skipping base baseline.\n");
+    return false;
+  }
+
+  await run(
+    "cargo",
+    ["+nightly", "bench", "--bench", "parser", "--", "--noplot", "--save-baseline", "base"],
+    {
+      cwd: worktree,
+      env: envWith({ CARGO_TARGET_DIR: repoPath("target") }),
+      outputPath: BASE_OUTPUT,
+    },
+  );
+  return true;
+}
+
+async function benchmarkCurrent(hasBaseBaseline) {
+  const args = ["+nightly", "bench", "--bench", "parser", "--", "--noplot"];
+  if (hasBaseBaseline) {
+    args.push("--baseline", "base");
+  }
+  await run("cargo", args, { outputPath: CURRENT_OUTPUT });
+}
+
+async function publishSummary() {
+  if (process.env.GITHUB_STEP_SUMMARY && !fileExists(process.env.GITHUB_STEP_SUMMARY)) {
+    fs.closeSync(fs.openSync(process.env.GITHUB_STEP_SUMMARY, "a"));
+  }
+
+  const generatedBytes = process.env.RDBINSIGHT_BENCH_GENERATED_BYTES || "67108864";
+
+  core.summary
+    .addHeading("Parser benchmark", 2)
+    .addList([
+      `Input: generated ${generatedBytes} byte synthetic string-record RDB unless RDBINSIGHT_BENCH_RDB is set.`,
+      "Benchmark excludes disk I/O; RDB bytes are prepared before timing starts.",
+    ]);
+
+  if (fileExists(BASE_OUTPUT)) {
+    core.summary
+      .addHeading("Base", 3)
+      .addCodeBlock(fs.readFileSync(BASE_OUTPUT, "utf8"), "text");
+  }
+
+  if (fileExists(CURRENT_OUTPUT)) {
+    core.summary
+      .addHeading("Current", 3)
+      .addCodeBlock(fs.readFileSync(CURRENT_OUTPUT, "utf8"), "text");
+  }
+
+  await core.summary.write();
+}
+
+async function cleanupBaseWorktree() {
+  if (!process.env.GITHUB_RUN_ID) {
+    return;
+  }
+  const worktree = path.join(os.tmpdir(), `rdbinsight-base-${process.env.GITHUB_RUN_ID}`);
+  if (!fileExists(worktree)) {
+    return;
+  }
+  try {
+    await run("git", ["worktree", "remove", "--force", worktree]);
+  } catch (err) {
+    core.warning(`Failed to remove base worktree: ${err.message}`);
+  }
+}
+
+async function main() {
+  let runError = null;
+
+  try {
+    const hasBaseBaseline = await benchmarkBase();
+    await benchmarkCurrent(hasBaseBaseline);
+  } catch (err) {
+    runError = err;
+  } finally {
+    await publishSummary();
+    await cleanupBaseWorktree();
+  }
+
+  if (runError) {
+    core.setFailed(runError.message);
+  }
+}
+
+main().catch((err) => {
+  core.setFailed(err.message);
+});

--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -42,7 +42,6 @@ async function run(command, args, options = {}) {
       ignoreReturnCode: true,
       listeners: {
         stdout: (chunk) => output?.write(chunk),
-        stderr: (chunk) => output?.write(chunk),
       },
     });
     if (exitCode !== 0) {

--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -98,11 +98,15 @@ async function publishSummary() {
   }
 
   const generatedBytes = process.env.RDBINSIGHT_BENCH_GENERATED_BYTES || "67108864";
+  const profile = process.env.RDBINSIGHT_BENCH_PROFILE || "string";
+  const inputDescription = process.env.RDBINSIGHT_BENCH_RDB
+    ? `Input: external RDB from ${process.env.RDBINSIGHT_BENCH_RDB}.`
+    : `Input: generated ${generatedBytes} byte synthetic ${profile} RDB profile.`;
 
   core.summary
     .addHeading("Parser benchmark", 2)
     .addList([
-      `Input: generated ${generatedBytes} byte synthetic string-record RDB unless RDBINSIGHT_BENCH_RDB is set.`,
+      inputDescription,
       "Benchmark excludes disk I/O; RDB bytes are prepared before timing starts.",
     ]);
 

--- a/.github/actions/parser-benchmark/package-lock.json
+++ b/.github/actions/parser-benchmark/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "@rdbinsight/parser-benchmark-ci",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@rdbinsight/parser-benchmark-ci",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@actions/core": "^3.0.1",
+        "@actions/exec": "^3.0.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "license": "MIT"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    }
+  }
+}

--- a/.github/actions/parser-benchmark/package.json
+++ b/.github/actions/parser-benchmark/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@rdbinsight/parser-benchmark-ci",
+  "version": "1.0.0",
+  "description": "Run parser benchmark comparison in CI",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@actions/core": "^3.0.1",
+    "@actions/exec": "^3.0.0"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,53 +114,13 @@ jobs:
           echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
 
-      - name: Benchmark base branch
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Install parser benchmark helper dependencies
+        run: npm ci --ignore-scripts --prefix .github/actions/parser-benchmark
+
+      - name: Run parser benchmark
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -euo pipefail
-          git worktree add ../rdbinsight-base "$BASE_SHA"
-          if [ ! -f ../rdbinsight-base/benches/parser.rs ]; then
-            echo "Base branch has no parser benchmark; skipping base baseline." | tee parser-benchmark-base.txt
-            exit 0
-          fi
-          (
-            cd ../rdbinsight-base
-            CARGO_TARGET_DIR="$GITHUB_WORKSPACE/target" \
-              cargo +nightly bench --bench parser -- --noplot --save-baseline base
-          ) | tee parser-benchmark-base.txt
-
-      - name: Benchmark current commit
-        run: |
-          set -euo pipefail
-          if [ -d target/criterion/parser ]; then
-            cargo +nightly bench --bench parser -- --noplot --baseline base | tee parser-benchmark-current.txt
-          else
-            cargo +nightly bench --bench parser -- --noplot | tee parser-benchmark-current.txt
-          fi
-
-      - name: Publish benchmark summary
-        if: always()
-        run: |
-          {
-            echo "## Parser benchmark"
-            echo
-            echo "- Input: generated ${RDBINSIGHT_BENCH_GENERATED_BYTES} byte synthetic string-record RDB unless RDBINSIGHT_BENCH_RDB is set."
-            echo "- Benchmark excludes disk I/O; RDB bytes are prepared before timing starts."
-            echo
-            if [ -f parser-benchmark-base.txt ]; then
-              echo "### Base"
-              echo '```text'
-              cat parser-benchmark-base.txt
-              echo '```'
-              echo
-            fi
-            echo "### Current"
-            echo '```text'
-            cat parser-benchmark-current.txt
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: node .github/actions/parser-benchmark/index.js
 
       - name: Upload benchmark artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,90 @@ jobs:
         if: always()
         run: ${SCCACHE_PATH} --show-stats
 
+  parser-benchmark:
+    name: Parser Benchmark
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RDBINSIGHT_BENCH_GENERATED_BYTES: "67108864"
+      RDBINSIGHT_BENCH_SAMPLE_SIZE: "10"
+      RDBINSIGHT_BENCH_WARM_UP_SECS: "1"
+      RDBINSIGHT_BENCH_MEASUREMENT_SECS: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+
+      - name: Enable sccache for Rust builds
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+
+      - name: Benchmark base branch
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git worktree add ../rdbinsight-base "$BASE_SHA"
+          if [ ! -f ../rdbinsight-base/benches/parser.rs ]; then
+            echo "Base branch has no parser benchmark; skipping base baseline." | tee parser-benchmark-base.txt
+            exit 0
+          fi
+          (
+            cd ../rdbinsight-base
+            CARGO_TARGET_DIR="$GITHUB_WORKSPACE/target" \
+              cargo +nightly bench --bench parser -- --noplot --save-baseline base
+          ) | tee parser-benchmark-base.txt
+
+      - name: Benchmark current commit
+        run: |
+          set -euo pipefail
+          if [ -d target/criterion/parser ]; then
+            cargo +nightly bench --bench parser -- --noplot --baseline base | tee parser-benchmark-current.txt
+          else
+            cargo +nightly bench --bench parser -- --noplot | tee parser-benchmark-current.txt
+          fi
+
+      - name: Publish benchmark summary
+        if: always()
+        run: |
+          {
+            echo "## Parser benchmark"
+            echo
+            echo "- Input: generated ${RDBINSIGHT_BENCH_GENERATED_BYTES} byte synthetic string-record RDB unless RDBINSIGHT_BENCH_RDB is set."
+            echo "- Benchmark excludes disk I/O; RDB bytes are prepared before timing starts."
+            echo
+            if [ -f parser-benchmark-base.txt ]; then
+              echo "### Base"
+              echo '```text'
+              cat parser-benchmark-base.txt
+              echo '```'
+              echo
+            fi
+            echo "### Current"
+            echo '```text'
+            cat parser-benchmark-current.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parser-benchmark
+          path: |
+            parser-benchmark-*.txt
+            target/criterion
+
   docker-builds:
     name: Docker Build (${{ matrix.name }})
     needs: [lint, coverage]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify version consistency (tag/Cargo.toml/CHANGELOG)
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -47,7 +47,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install nightly Rust toolchain (llvm-tools-preview)
         id: toolchain
@@ -77,7 +77,7 @@ jobs:
             --codecov --output-path codecov.json
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           use_oidc: true
           files: codecov.json
@@ -99,7 +99,7 @@ jobs:
       RDBINSIGHT_BENCH_MEASUREMENT_SECS: "1"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload benchmark artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: parser-benchmark
           path: |
@@ -191,13 +191,13 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -211,13 +211,13 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.vars.outputs.image }}
 
       - name: Build and push (${{ matrix.platform }})
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -233,7 +233,7 @@ jobs:
         shell: bash
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.name }}
           path: digest.env
@@ -248,10 +248,10 @@ jobs:
       packages: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -264,20 +264,20 @@ jobs:
           echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Download digest (amd64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: digest-amd64
           path: digests/amd64
 
       - name: Download digest (arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: digest-arm64
           path: digests/arm64
 
       - name: Docker metadata (recompute tags)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.vars.outputs.image }}
           flavor: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
     permissions:
       contents: read
     env:
+      RDBINSIGHT_BENCH_PROFILE: "mixed"
       RDBINSIGHT_BENCH_GENERATED_BYTES: "67108864"
       RDBINSIGHT_BENCH_SAMPLE_SIZE: "10"
       RDBINSIGHT_BENCH_WARM_UP_SECS: "1"

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Create demo page
         run: |
@@ -42,10 +42,10 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "_site"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-test-images.yml
+++ b/.github/workflows/publish-test-images.yml
@@ -34,17 +34,17 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compute image name (lowercase)
         id: vars
         run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}/redis" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build and push (single-arch)
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./tests/common/Dockerfile
@@ -68,7 +68,7 @@ jobs:
           echo "DIGEST=${{ steps.build.outputs.digest }}" >> digest.env
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.redis }}-${{ matrix.platform }}
           path: digest.env
@@ -90,23 +90,23 @@ jobs:
         run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}/redis" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download digest (amd64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: digest-${{ matrix.redis }}-amd64
           path: digests/amd64
 
       - name: Download digest (arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: digest-${{ matrix.redis }}-arm64
           path: digests/arm64

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ rdb_report_*.html
 /tmp
 .idea/
 .vscode/
+.github/actions/parser-benchmark/node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +63,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -670,6 +685,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +735,33 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -970,6 +1018,60 @@ name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1841,6 +1943,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2392,6 +2503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2521,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2570,6 +2697,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polonius-the-crab"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,7 +2867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2871,6 +3026,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rdbinsight"
 version = "0.1.0"
 dependencies = [
@@ -2886,11 +3061,12 @@ dependencies = [
  "clap_complete",
  "clickhouse",
  "crc",
+ "criterion",
  "futures-util",
  "hex",
  "http",
  "hyper-util",
- "itertools",
+ "itertools 0.14.0",
  "lz4_flex 0.13.1",
  "lzf",
  "memchr",
@@ -3556,7 +3732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cdc8fd3fa6696f64950aaa347b05c4f57aa3e0f03947b22cc0a1fad4bbe42"
 dependencies = [
  "convert_case",
- "itertools",
+ "itertools 0.14.0",
  "parsel",
  "proc-macro2",
  "quote",
@@ -3691,7 +3867,7 @@ dependencies = [
  "ferroid",
  "futures",
  "http",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -3806,6 +3982,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ wincode = { version = "0.5.5", features = ["derive"] }
 shadow-rs = "2.0.0"
 
 [dev-dependencies]
+criterion = "0.8.2"
 tempfile = "3.23.0"
 testcontainers = { version = "0.27.0", features = ["http_wait"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+
+[[bench]]
+name = "parser"
+harness = false

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,0 +1,154 @@
+use std::{env, fs, hint::black_box, path::PathBuf, time::Duration};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rdbinsight::parser::{RDBFileParser, core::buffer::Buffer, error::NeedMoreData};
+
+const DEFAULT_GENERATED_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_CHUNK_SIZE: usize = 64 * 1024;
+const DEFAULT_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_duration(name: &str, default_secs: u64) -> Duration {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(default_secs))
+}
+
+fn push_rdb_len(out: &mut Vec<u8>, len: usize) {
+    match len {
+        0..=0x3f => out.push(len as u8),
+        0x40..=0x3fff => {
+            out.push(((len >> 8) as u8) | 0x40);
+            out.push(len as u8);
+        }
+        _ => {
+            out.push(0x80);
+            out.extend_from_slice(&(len as u32).to_be_bytes());
+        }
+    }
+}
+
+fn push_rdb_str(out: &mut Vec<u8>, value: &[u8]) {
+    push_rdb_len(out, value.len());
+    out.extend_from_slice(value);
+}
+
+fn synthetic_rdb(target_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(target_bytes + 1024);
+    out.extend_from_slice(b"REDIS0011");
+
+    let value = vec![b'x'; 1024];
+    let mut index = 0_u64;
+    while out.len() < target_bytes {
+        out.push(0x00); // String value type.
+        let key = format!("bench:key:{index:016}");
+        push_rdb_str(&mut out, key.as_bytes());
+        push_rdb_str(&mut out, &value);
+        index += 1;
+    }
+
+    out.push(0xff); // EOF.
+    out.extend_from_slice(&0_u64.to_le_bytes()); // Checksum placeholder; parser does not validate it.
+    out
+}
+
+fn benchmark_input() -> (String, Vec<u8>) {
+    if let Ok(path) = env::var("RDBINSIGHT_BENCH_RDB") {
+        let path = PathBuf::from(path);
+        let label = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("custom-rdb")
+            .to_owned();
+        let data = fs::read(&path)
+            .unwrap_or_else(|err| panic!("failed to read benchmark RDB {}: {err}", path.display()));
+        return (label, data);
+    }
+
+    let target_bytes = env_usize("RDBINSIGHT_BENCH_GENERATED_BYTES", DEFAULT_GENERATED_BYTES);
+    (
+        format!("synthetic-string-records-{}MiB", target_bytes / 1024 / 1024),
+        synthetic_rdb(target_bytes),
+    )
+}
+
+fn parse_rdb(data: &[u8], chunk_size: usize, buffer_size: usize) -> usize {
+    let mut parser = RDBFileParser::default();
+    let mut buffer = Buffer::new(buffer_size);
+    let mut offset = 0;
+    let mut item_count = 0;
+
+    loop {
+        match parser.poll_next(&mut buffer) {
+            Ok(Some(item)) => {
+                black_box(item);
+                item_count += 1;
+            }
+            Ok(None) => {
+                assert_eq!(buffer.len(), 0, "parser finished with unconsumed bytes");
+                return item_count;
+            }
+            Err(err) if err.is::<NeedMoreData>() => {
+                if buffer.is_finished() {
+                    panic!("parser requested more data after input was marked finished");
+                }
+                if offset == data.len() {
+                    buffer.set_finished();
+                    continue;
+                }
+
+                let read_len = chunk_size
+                    .min(buffer.remain_capacity())
+                    .min(data.len() - offset);
+                assert!(
+                    read_len > 0,
+                    "parser buffer is full; increase RDBINSIGHT_BENCH_BUFFER_BYTES"
+                );
+                buffer
+                    .extend(&data[offset..offset + read_len])
+                    .expect("benchmark buffer should have enough capacity");
+                offset += read_len;
+            }
+            Err(err) => panic!("parser failed: {err:#}"),
+        }
+    }
+}
+
+fn bench_parser(c: &mut Criterion) {
+    let (label, data) = benchmark_input();
+    let chunk_size = env_usize("RDBINSIGHT_BENCH_CHUNK_BYTES", DEFAULT_CHUNK_SIZE);
+    let buffer_size = env_usize("RDBINSIGHT_BENCH_BUFFER_BYTES", DEFAULT_BUFFER_SIZE);
+
+    let mut group = c.benchmark_group("parser");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+    group.bench_with_input(
+        BenchmarkId::new("parse_rdb", label),
+        &data,
+        |bench, input| {
+            bench.iter(|| parse_rdb(black_box(input), chunk_size, buffer_size));
+        },
+    );
+    group.finish();
+}
+
+fn criterion_config() -> Criterion {
+    Criterion::default()
+        .sample_size(env_usize("RDBINSIGHT_BENCH_SAMPLE_SIZE", 10).max(10))
+        .warm_up_time(env_duration("RDBINSIGHT_BENCH_WARM_UP_SECS", 1))
+        .measurement_time(env_duration("RDBINSIGHT_BENCH_MEASUREMENT_SECS", 1))
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets = bench_parser
+}
+criterion_main!(benches);

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -41,23 +41,174 @@ fn push_rdb_str(out: &mut Vec<u8>, value: &[u8]) {
     out.extend_from_slice(value);
 }
 
-fn synthetic_rdb(target_bytes: usize) -> Vec<u8> {
+fn push_string_record(out: &mut Vec<u8>, key: &[u8], value: &[u8]) {
+    out.push(0x00); // RDB_TYPE_STRING.
+    push_rdb_str(out, key);
+    push_rdb_str(out, value);
+}
+
+fn push_list_record(out: &mut Vec<u8>, key: &[u8], values: &[&[u8]]) {
+    out.push(0x01); // RDB_TYPE_LIST.
+    push_rdb_str(out, key);
+    push_rdb_len(out, values.len());
+    for value in values {
+        push_rdb_str(out, value);
+    }
+}
+
+fn push_set_record(out: &mut Vec<u8>, key: &[u8], values: &[&[u8]]) {
+    out.push(0x02); // RDB_TYPE_SET.
+    push_rdb_str(out, key);
+    push_rdb_len(out, values.len());
+    for value in values {
+        push_rdb_str(out, value);
+    }
+}
+
+fn push_zset_record(out: &mut Vec<u8>, key: &[u8], values: &[(&[u8], &[u8])]) {
+    out.push(0x03); // RDB_TYPE_ZSET.
+    push_rdb_str(out, key);
+    push_rdb_len(out, values.len());
+    for (member, score) in values {
+        push_rdb_str(out, member);
+        push_rdb_str(out, score);
+    }
+}
+
+fn push_zset2_record(out: &mut Vec<u8>, key: &[u8], values: &[(&[u8], f64)]) {
+    out.push(0x05); // RDB_TYPE_ZSET_2.
+    push_rdb_str(out, key);
+    push_rdb_len(out, values.len());
+    for (member, score) in values {
+        push_rdb_str(out, member);
+        out.extend_from_slice(&score.to_le_bytes());
+    }
+}
+
+fn push_hash_record(out: &mut Vec<u8>, key: &[u8], pairs: &[(&[u8], &[u8])]) {
+    out.push(0x04); // RDB_TYPE_HASH.
+    push_rdb_str(out, key);
+    push_rdb_len(out, pairs.len());
+    for (field, value) in pairs {
+        push_rdb_str(out, field);
+        push_rdb_str(out, value);
+    }
+}
+
+fn push_expire_ms(out: &mut Vec<u8>, expire_at_ms: u64) {
+    out.push(0xfc); // RDB_OPCODE_EXPIRETIME_MS.
+    out.extend_from_slice(&expire_at_ms.to_le_bytes());
+}
+
+fn push_select_db(out: &mut Vec<u8>, db: usize) {
+    out.push(0xfe); // RDB_OPCODE_SELECTDB.
+    push_rdb_len(out, db);
+}
+
+fn push_resize_db(out: &mut Vec<u8>, keys: usize, expires: usize) {
+    out.push(0xfb); // RDB_OPCODE_RESIZEDB.
+    push_rdb_len(out, keys);
+    push_rdb_len(out, expires);
+}
+
+fn synthetic_string_rdb(target_bytes: usize) -> Vec<u8> {
     let mut out = Vec::with_capacity(target_bytes + 1024);
     out.extend_from_slice(b"REDIS0011");
 
     let value = vec![b'x'; 1024];
     let mut index = 0_u64;
     while out.len() < target_bytes {
-        out.push(0x00); // String value type.
         let key = format!("bench:key:{index:016}");
-        push_rdb_str(&mut out, key.as_bytes());
-        push_rdb_str(&mut out, &value);
+        push_string_record(&mut out, key.as_bytes(), &value);
         index += 1;
     }
 
     out.push(0xff); // EOF.
     out.extend_from_slice(&0_u64.to_le_bytes()); // Checksum placeholder; parser does not validate it.
     out
+}
+
+fn synthetic_mixed_rdb(target_bytes: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(target_bytes + 1024);
+    out.extend_from_slice(b"REDIS0011");
+    push_select_db(&mut out, 0);
+    push_resize_db(&mut out, 1024, 128);
+
+    let large_value = vec![b'x'; 1024];
+    let members: [&[u8]; 8] = [
+        b"alpha", b"bravo", b"charlie", b"delta", b"echo", b"foxtrot", b"golf", b"hotel",
+    ];
+    let zset_scores: [(&[u8], &[u8]); 8] = [
+        (b"alpha", b"1.25"),
+        (b"bravo", b"2.50"),
+        (b"charlie", b"3.75"),
+        (b"delta", b"4.00"),
+        (b"echo", b"5.25"),
+        (b"foxtrot", b"6.50"),
+        (b"golf", b"7.75"),
+        (b"hotel", b"8.00"),
+    ];
+    let zset2_scores: [(&[u8], f64); 8] = [
+        (b"alpha", 1.25),
+        (b"bravo", 2.50),
+        (b"charlie", 3.75),
+        (b"delta", 4.00),
+        (b"echo", 5.25),
+        (b"foxtrot", 6.50),
+        (b"golf", 7.75),
+        (b"hotel", 8.00),
+    ];
+    let hash_pairs: [(&[u8], &[u8]); 8] = [
+        (b"name", b"benchmark"),
+        (b"region", b"ci"),
+        (b"owner", b"parser"),
+        (b"state", b"active"),
+        (b"tier", b"hot"),
+        (b"format", b"rdb"),
+        (b"version", b"0011"),
+        (b"profile", b"mixed"),
+    ];
+
+    let mut index = 0_u64;
+    while out.len() < target_bytes {
+        let key = format!("bench:mixed:{index:016}");
+        if index.is_multiple_of(10) {
+            push_expire_ms(&mut out, 4_102_444_800_000);
+        }
+
+        match index % 6 {
+            0 => push_string_record(&mut out, key.as_bytes(), &large_value),
+            1 => push_list_record(&mut out, key.as_bytes(), &members),
+            2 => push_set_record(&mut out, key.as_bytes(), &members),
+            3 => push_zset_record(&mut out, key.as_bytes(), &zset_scores),
+            4 => push_zset2_record(&mut out, key.as_bytes(), &zset2_scores),
+            _ => push_hash_record(&mut out, key.as_bytes(), &hash_pairs),
+        }
+        index += 1;
+    }
+
+    out.push(0xff); // EOF.
+    out.extend_from_slice(&0_u64.to_le_bytes()); // Checksum placeholder; parser does not validate it.
+    out
+}
+
+fn generated_benchmark_input(target_bytes: usize) -> (String, Vec<u8>) {
+    let profile = env::var("RDBINSIGHT_BENCH_PROFILE").unwrap_or_else(|_| "mixed".to_owned());
+    let target_mib = target_bytes / 1024 / 1024;
+
+    match profile.as_str() {
+        "string" => (
+            format!("synthetic-string-records-{target_mib}MiB"),
+            synthetic_string_rdb(target_bytes),
+        ),
+        "mixed" => (
+            format!("synthetic-mixed-raw-types-{target_mib}MiB"),
+            synthetic_mixed_rdb(target_bytes),
+        ),
+        other => {
+            panic!("unsupported RDBINSIGHT_BENCH_PROFILE {other:?}; expected string or mixed")
+        }
+    }
 }
 
 fn benchmark_input() -> (String, Vec<u8>) {
@@ -74,10 +225,7 @@ fn benchmark_input() -> (String, Vec<u8>) {
     }
 
     let target_bytes = env_usize("RDBINSIGHT_BENCH_GENERATED_BYTES", DEFAULT_GENERATED_BYTES);
-    (
-        format!("synthetic-string-records-{}MiB", target_bytes / 1024 / 1024),
-        synthetic_rdb(target_bytes),
-    )
+    generated_benchmark_input(target_bytes)
 }
 
 fn parse_rdb(data: &[u8], chunk_size: usize, buffer_size: usize) -> usize {

--- a/justfile
+++ b/justfile
@@ -39,6 +39,9 @@ coverage: init_test
     grcov target/coverage/lcov.info --output-types html --source-dir . --branch --output-path target/coverage
     @echo "Report ready: target/coverage/html/index.html"
 
+bench_parser:
+    cargo +nightly bench --bench parser -- --noplot
+
 up_dev:
     docker-compose -f dev/docker-compose.yml up -d --force-recreate --renew-anon-volumes --wait
 


### PR DESCRIPTION
## Why

- Parser performance is not visible in CI today, so parser refactors can regress throughput without an obvious review signal.
- A useful default benchmark should exercise more than raw string records while still producing one stable CI datapoint.
- Existing workflows also used older third-party action majors.

## What

- Add a Criterion parser benchmark that runs one 64 MiB mixed synthetic RDB by default, covering multiple raw Redis record types and common RDB opcodes in a single scenario.
- Support real-file benchmarks through `RDBINSIGHT_BENCH_RDB` and local synthetic profile selection through `RDBINSIGHT_BENCH_PROFILE`.
- Add a Node.js GitHub Actions helper for benchmark execution, job summary output, and artifact upload.
- Add `just bench_parser` for local runs.
- Update GitHub, Docker, Pages, artifact, and Codecov actions to current major versions.
