### PR TITLE
ci(parser): report benchmark comparisons in PRs

### DIFF
--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -89,12 +89,10 @@ async function benchmarkBase() {
   return true;
 }
 
-async function benchmarkCurrent(hasBaseBaseline) {
-  const args = ["+nightly", "bench", "--bench", "parser", "--", "--noplot"];
-  if (hasBaseBaseline) {
-    args.push("--baseline", "base");
-  }
-  await run("cargo", args, { outputPath: CURRENT_OUTPUT });
+async function benchmarkCurrent() {
+  await run("cargo", ["+nightly", "bench", "--bench", "parser", "--", "--noplot"], {
+    outputPath: CURRENT_OUTPUT,
+  });
 }
 
 function walkFiles(root, basename, out = []) {
@@ -364,7 +362,7 @@ async function main() {
   try {
     fs.rmSync(repoPath("target", "criterion"), { recursive: true, force: true });
     hasBaseBaseline = await benchmarkBase();
-    await benchmarkCurrent(hasBaseBaseline);
+    await benchmarkCurrent();
   } catch (err) {
     runError = err;
   } finally {

--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -9,6 +9,9 @@ import path from "node:path";
 const BASE_OUTPUT = "parser-benchmark-base.txt";
 const CURRENT_OUTPUT = "parser-benchmark-current.txt";
 const COMMENT_MARKER = "<!-- rdbinsight-parser-benchmark -->";
+const CRITERION_DIR = repoPath("target", "criterion");
+const BASE_CRITERION_DIR = repoPath("target", "criterion-base");
+const CURRENT_CRITERION_DIR = repoPath("target", "criterion-current");
 
 function repoPath(...segments) {
   return path.join(process.env.GITHUB_WORKSPACE || process.cwd(), ...segments);
@@ -20,6 +23,13 @@ function fileExists(filePath) {
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function copyCriterionOutput(targetPath) {
+  fs.rmSync(targetPath, { recursive: true, force: true });
+  if (fileExists(CRITERION_DIR)) {
+    fs.cpSync(CRITERION_DIR, targetPath, { recursive: true });
+  }
 }
 
 function envWith(overrides) {
@@ -86,13 +96,16 @@ async function benchmarkBase() {
       outputPath: BASE_OUTPUT,
     },
   );
+  copyCriterionOutput(BASE_CRITERION_DIR);
   return true;
 }
 
 async function benchmarkCurrent() {
+  fs.rmSync(CRITERION_DIR, { recursive: true, force: true });
   await run("cargo", ["+nightly", "bench", "--bench", "parser", "--", "--noplot"], {
     outputPath: CURRENT_OUTPUT,
   });
+  copyCriterionOutput(CURRENT_CRITERION_DIR);
 }
 
 function walkFiles(root, basename, out = []) {
@@ -118,8 +131,8 @@ function benchmarkName(criterionRoot, estimatesPath) {
   return segments.slice(0, -2).join("/");
 }
 
-function benchmarkJsonPath(criterionRoot, name) {
-  return path.join(criterionRoot, ...name.split("/"), "new", "benchmark.json");
+function benchmarkJsonPath(name) {
+  return path.join(CURRENT_CRITERION_DIR, ...name.split("/"), "new", "benchmark.json");
 }
 
 function formatDuration(ns) {
@@ -162,8 +175,8 @@ function medianPointEstimate(filePath) {
   return readJson(filePath).median.point_estimate;
 }
 
-function benchmarkBytes(criterionRoot, name) {
-  const filePath = benchmarkJsonPath(criterionRoot, name);
+function benchmarkBytes(name) {
+  const filePath = benchmarkJsonPath(name);
   if (!fileExists(filePath)) {
     return Number.NaN;
   }
@@ -176,22 +189,21 @@ function benchmarkBytes(criterionRoot, name) {
 }
 
 function collectBenchmarkRows(hasBaseBaseline) {
-  const criterionRoot = repoPath("target", "criterion");
   const rows = [];
 
-  for (const estimatesPath of walkFiles(criterionRoot, "estimates.json")) {
+  for (const estimatesPath of walkFiles(CURRENT_CRITERION_DIR, "estimates.json")) {
     if (!estimatesPath.endsWith(`${path.sep}new${path.sep}estimates.json`)) {
       continue;
     }
 
-    const name = benchmarkName(criterionRoot, estimatesPath);
-    const baseEstimatesPath = path.join(path.dirname(path.dirname(estimatesPath)), "base", "estimates.json");
+    const name = benchmarkName(CURRENT_CRITERION_DIR, estimatesPath);
+    const baseEstimatesPath = path.join(BASE_CRITERION_DIR, ...name.split("/"), "base", "estimates.json");
     const currentNs = medianPointEstimate(estimatesPath);
     const baseNs =
       hasBaseBaseline && fileExists(baseEstimatesPath)
         ? medianPointEstimate(baseEstimatesPath)
         : Number.NaN;
-    const bytes = benchmarkBytes(criterionRoot, name);
+    const bytes = benchmarkBytes(name);
 
     rows.push({
       name,
@@ -403,6 +415,8 @@ async function main() {
 
   try {
     fs.rmSync(repoPath("target", "criterion"), { recursive: true, force: true });
+    fs.rmSync(BASE_CRITERION_DIR, { recursive: true, force: true });
+    fs.rmSync(CURRENT_CRITERION_DIR, { recursive: true, force: true });
     hasBaseBaseline = await benchmarkBase();
     await benchmarkCurrent();
   } catch (err) {

--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -12,6 +12,8 @@ const COMMENT_MARKER = "<!-- rdbinsight-parser-benchmark -->";
 const CRITERION_DIR = repoPath("target", "criterion");
 const BASE_CRITERION_DIR = repoPath("target", "criterion-base");
 const CURRENT_CRITERION_DIR = repoPath("target", "criterion-current");
+const BENCHMARK_NAME_PATTERN =
+  /^parser\/parse_rdb\/synthetic-(?:(?:string|list|set|hash|zset|zset2)-records|mixed-raw-types)-[1-9][0-9]*MiB$/;
 
 function repoPath(...segments) {
   return path.join(process.env.GITHUB_WORKSPACE || process.cwd(), ...segments);
@@ -171,6 +173,18 @@ function formatChange(currentNs, baseNs) {
   return `${prefix}${change.toFixed(2)}% ${direction}`;
 }
 
+function markdownTableCell(value) {
+  return String(value)
+    .slice(0, 200)
+    .replaceAll("\\", "\\\\")
+    .replaceAll("|", "\\|")
+    .replaceAll("`", "\\`")
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 function medianPointEstimate(filePath) {
   return readJson(filePath).median.point_estimate;
 }
@@ -197,6 +211,10 @@ function collectBenchmarkRows(hasBaseBaseline) {
     }
 
     const name = benchmarkName(CURRENT_CRITERION_DIR, estimatesPath);
+    if (!BENCHMARK_NAME_PATTERN.test(name)) {
+      core.warning(`Skipping unexpected benchmark name: ${name}`);
+      continue;
+    }
     const baseEstimatesPath = path.join(BASE_CRITERION_DIR, ...name.split("/"), "base", "estimates.json");
     const currentNs = medianPointEstimate(estimatesPath);
     const baseNs =
@@ -229,7 +247,7 @@ function benchmarkMarkdownTable(rows) {
 
   for (const row of rows) {
     table.push(
-      `| \`${row.name}\` | ${formatDuration(row.baseNs)} | ${formatDuration(row.currentNs)} | ${formatChange(row.currentNs, row.baseNs)} | ${formatThroughput(row.bytes, row.currentNs)} |`,
+      `| \`${markdownTableCell(row.name)}\` | ${markdownTableCell(formatDuration(row.baseNs))} | ${markdownTableCell(formatDuration(row.currentNs))} | ${markdownTableCell(formatChange(row.currentNs, row.baseNs))} | ${markdownTableCell(formatThroughput(row.bytes, row.currentNs))} |`,
     );
   }
 

--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -12,8 +12,6 @@ const COMMENT_MARKER = "<!-- rdbinsight-parser-benchmark -->";
 const CRITERION_DIR = repoPath("target", "criterion");
 const BASE_CRITERION_DIR = repoPath("target", "criterion-base");
 const CURRENT_CRITERION_DIR = repoPath("target", "criterion-current");
-const BENCHMARK_NAME_PATTERN =
-  /^parser\/parse_rdb\/synthetic-(?:(?:string|list|set|hash|zset|zset2)-records|mixed-raw-types)-[1-9][0-9]*MiB$/;
 
 function repoPath(...segments) {
   return path.join(process.env.GITHUB_WORKSPACE || process.cwd(), ...segments);
@@ -211,10 +209,6 @@ function collectBenchmarkRows(hasBaseBaseline) {
     }
 
     const name = benchmarkName(CURRENT_CRITERION_DIR, estimatesPath);
-    if (!BENCHMARK_NAME_PATTERN.test(name)) {
-      core.warning(`Skipping unexpected benchmark name: ${name}`);
-      continue;
-    }
     const baseEstimatesPath = path.join(BASE_CRITERION_DIR, ...name.split("/"), "base", "estimates.json");
     const currentNs = medianPointEstimate(estimatesPath);
     const baseNs =

--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -8,6 +8,7 @@ import path from "node:path";
 
 const BASE_OUTPUT = "parser-benchmark-base.txt";
 const CURRENT_OUTPUT = "parser-benchmark-current.txt";
+const COMMENT_MARKER = "<!-- rdbinsight-parser-benchmark -->";
 
 function repoPath(...segments) {
   return path.join(process.env.GITHUB_WORKSPACE || process.cwd(), ...segments);
@@ -15,6 +16,10 @@ function repoPath(...segments) {
 
 function fileExists(filePath) {
   return fs.existsSync(filePath);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
 function envWith(overrides) {
@@ -92,23 +97,164 @@ async function benchmarkCurrent(hasBaseBaseline) {
   await run("cargo", args, { outputPath: CURRENT_OUTPUT });
 }
 
-async function publishSummary() {
+function walkFiles(root, basename, out = []) {
+  if (!fileExists(root)) {
+    return out;
+  }
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(entryPath, basename, out);
+    } else if (entry.name === basename) {
+      out.push(entryPath);
+    }
+  }
+
+  return out;
+}
+
+function benchmarkName(criterionRoot, estimatesPath) {
+  const relative = path.relative(criterionRoot, estimatesPath);
+  const segments = relative.split(path.sep);
+  return segments.slice(0, -2).join("/");
+}
+
+function benchmarkJsonPath(criterionRoot, name) {
+  return path.join(criterionRoot, ...name.split("/"), "new", "benchmark.json");
+}
+
+function formatDuration(ns) {
+  if (!Number.isFinite(ns)) {
+    return "-";
+  }
+  if (ns < 1_000) {
+    return `${ns.toFixed(2)} ns`;
+  }
+  if (ns < 1_000_000) {
+    return `${(ns / 1_000).toFixed(2)} us`;
+  }
+  if (ns < 1_000_000_000) {
+    return `${(ns / 1_000_000).toFixed(2)} ms`;
+  }
+  return `${(ns / 1_000_000_000).toFixed(2)} s`;
+}
+
+function formatThroughput(bytes, ns) {
+  if (!Number.isFinite(bytes) || !Number.isFinite(ns) || ns <= 0) {
+    return "-";
+  }
+
+  const mibPerSecond = bytes / (1024 * 1024) / (ns / 1_000_000_000);
+  return `${mibPerSecond.toFixed(2)} MiB/s`;
+}
+
+function formatChange(currentNs, baseNs) {
+  if (!Number.isFinite(currentNs) || !Number.isFinite(baseNs) || baseNs <= 0) {
+    return "-";
+  }
+
+  const change = (currentNs / baseNs - 1) * 100;
+  const prefix = change > 0 ? "+" : "";
+  const direction = change > 0 ? "slower" : change < 0 ? "faster" : "same";
+  return `${prefix}${change.toFixed(2)}% ${direction}`;
+}
+
+function medianPointEstimate(filePath) {
+  return readJson(filePath).median.point_estimate;
+}
+
+function benchmarkBytes(criterionRoot, name) {
+  const filePath = benchmarkJsonPath(criterionRoot, name);
+  if (!fileExists(filePath)) {
+    return Number.NaN;
+  }
+
+  const benchmark = readJson(filePath);
+  if (benchmark.throughput?.Bytes !== undefined) {
+    return benchmark.throughput.Bytes;
+  }
+  return Number.NaN;
+}
+
+function collectBenchmarkRows(hasBaseBaseline) {
+  const criterionRoot = repoPath("target", "criterion");
+  const rows = [];
+
+  for (const estimatesPath of walkFiles(criterionRoot, "estimates.json")) {
+    if (!estimatesPath.endsWith(`${path.sep}new${path.sep}estimates.json`)) {
+      continue;
+    }
+
+    const name = benchmarkName(criterionRoot, estimatesPath);
+    const baseEstimatesPath = path.join(path.dirname(path.dirname(estimatesPath)), "base", "estimates.json");
+    const currentNs = medianPointEstimate(estimatesPath);
+    const baseNs =
+      hasBaseBaseline && fileExists(baseEstimatesPath)
+        ? medianPointEstimate(baseEstimatesPath)
+        : Number.NaN;
+    const bytes = benchmarkBytes(criterionRoot, name);
+
+    rows.push({
+      name,
+      baseNs,
+      currentNs,
+      bytes,
+    });
+  }
+
+  rows.sort((a, b) => a.name.localeCompare(b.name));
+  return rows;
+}
+
+function benchmarkTable(rows) {
+  if (rows.length === 0) {
+    return "_No Criterion benchmark estimates were found._";
+  }
+
+  const table = [
+    "| Benchmark | Base median | Current median | Change | Current throughput |",
+    "| --- | ---: | ---: | ---: | ---: |",
+  ];
+
+  for (const row of rows) {
+    table.push(
+      `| \`${row.name}\` | ${formatDuration(row.baseNs)} | ${formatDuration(row.currentNs)} | ${formatChange(row.currentNs, row.baseNs)} | ${formatThroughput(row.bytes, row.currentNs)} |`,
+    );
+  }
+
+  return table.join("\n");
+}
+
+function benchmarkNotes() {
   if (process.env.GITHUB_STEP_SUMMARY && !fileExists(process.env.GITHUB_STEP_SUMMARY)) {
     fs.closeSync(fs.openSync(process.env.GITHUB_STEP_SUMMARY, "a"));
   }
 
-  const generatedBytes = process.env.RDBINSIGHT_BENCH_GENERATED_BYTES || "67108864";
-  const profile = process.env.RDBINSIGHT_BENCH_PROFILE || "string";
+  const generatedBytes = process.env.RDBINSIGHT_BENCH_GENERATED_BYTES || "16777216";
+  const profiles =
+    process.env.RDBINSIGHT_BENCH_PROFILES ||
+    process.env.RDBINSIGHT_BENCH_PROFILE ||
+    "string,list,set,hash,zset,zset2,mixed";
   const inputDescription = process.env.RDBINSIGHT_BENCH_RDB
     ? `Input: external RDB from ${process.env.RDBINSIGHT_BENCH_RDB}.`
-    : `Input: generated ${generatedBytes} byte synthetic ${profile} RDB profile.`;
+    : `Input: generated ${generatedBytes} byte synthetic RDB profiles: ${profiles}.`;
+
+  return [
+    inputDescription,
+    "Benchmark excludes disk I/O; RDB bytes are prepared before timing starts.",
+    "Positive change means the current PR is slower than the base commit.",
+  ];
+}
+
+async function publishSummary(rows) {
+  const notes = benchmarkNotes();
 
   core.summary
     .addHeading("Parser benchmark", 2)
-    .addList([
-      inputDescription,
-      "Benchmark excludes disk I/O; RDB bytes are prepared before timing starts.",
-    ]);
+    .addList(notes)
+    .addHeading("Comparison", 3)
+    .addRaw(`${benchmarkTable(rows)}\n`);
 
   if (fileExists(BASE_OUTPUT)) {
     core.summary
@@ -123,6 +269,77 @@ async function publishSummary() {
   }
 
   await core.summary.write();
+}
+
+function githubEvent() {
+  if (!process.env.GITHUB_EVENT_PATH || !fileExists(process.env.GITHUB_EVENT_PATH)) {
+    return {};
+  }
+  return readJson(process.env.GITHUB_EVENT_PATH);
+}
+
+async function githubRequest(method, route, body) {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository) {
+    throw new Error("GITHUB_TOKEN and GITHUB_REPOSITORY are required to update PR comments");
+  }
+
+  const response = await fetch(`https://api.github.com/repos/${repository}${route}`, {
+    method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${method} ${route} failed with ${response.status}: ${text}`);
+  }
+
+  return response.status === 204 ? null : response.json();
+}
+
+async function upsertPullRequestComment(rows) {
+  if (process.env.GITHUB_EVENT_NAME !== "pull_request") {
+    return;
+  }
+  if (!process.env.GITHUB_TOKEN) {
+    core.info("GITHUB_TOKEN is not available; skipping parser benchmark PR comment.");
+    return;
+  }
+
+  const event = githubEvent();
+  const number = event.pull_request?.number;
+  if (!number) {
+    core.info("Pull request number is not available; skipping parser benchmark PR comment.");
+    return;
+  }
+
+  const notes = benchmarkNotes().map((note) => `- ${note}`).join("\n");
+  const body = [
+    COMMENT_MARKER,
+    "## Parser benchmark",
+    "",
+    notes,
+    "",
+    benchmarkTable(rows),
+    "",
+    "_This comment is updated automatically by CI._",
+  ].join("\n");
+
+  const comments = await githubRequest("GET", `/issues/${number}/comments?per_page=100`);
+  const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+
+  if (existing) {
+    await githubRequest("PATCH", `/issues/comments/${existing.id}`, { body });
+  } else {
+    await githubRequest("POST", `/issues/${number}/comments`, { body });
+  }
 }
 
 async function cleanupBaseWorktree() {
@@ -142,14 +359,22 @@ async function cleanupBaseWorktree() {
 
 async function main() {
   let runError = null;
+  let hasBaseBaseline = false;
 
   try {
-    const hasBaseBaseline = await benchmarkBase();
+    fs.rmSync(repoPath("target", "criterion"), { recursive: true, force: true });
+    hasBaseBaseline = await benchmarkBase();
     await benchmarkCurrent(hasBaseBaseline);
   } catch (err) {
     runError = err;
   } finally {
-    await publishSummary();
+    const rows = collectBenchmarkRows(hasBaseBaseline);
+    await publishSummary(rows);
+    try {
+      await upsertPullRequestComment(rows);
+    } catch (err) {
+      core.warning(`Failed to update parser benchmark PR comment: ${err.message}`);
+    }
     await cleanupBaseWorktree();
   }
 

--- a/.github/actions/parser-benchmark/index.js
+++ b/.github/actions/parser-benchmark/index.js
@@ -205,7 +205,7 @@ function collectBenchmarkRows(hasBaseBaseline) {
   return rows;
 }
 
-function benchmarkTable(rows) {
+function benchmarkMarkdownTable(rows) {
   if (rows.length === 0) {
     return "_No Criterion benchmark estimates were found._";
   }
@@ -222,6 +222,48 @@ function benchmarkTable(rows) {
   }
 
   return table.join("\n");
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function benchmarkHtmlTable(rows) {
+  if (rows.length === 0) {
+    return "<p><em>No Criterion benchmark estimates were found.</em></p>";
+  }
+
+  const body = rows
+    .map(
+      (row) => `<tr>
+<td><code>${escapeHtml(row.name)}</code></td>
+<td align="right">${escapeHtml(formatDuration(row.baseNs))}</td>
+<td align="right">${escapeHtml(formatDuration(row.currentNs))}</td>
+<td align="right">${escapeHtml(formatChange(row.currentNs, row.baseNs))}</td>
+<td align="right">${escapeHtml(formatThroughput(row.bytes, row.currentNs))}</td>
+</tr>`,
+    )
+    .join("\n");
+
+  return `<table>
+<thead>
+<tr>
+<th>Benchmark</th>
+<th align="right">Base median</th>
+<th align="right">Current median</th>
+<th align="right">Change</th>
+<th align="right">Current throughput</th>
+</tr>
+</thead>
+<tbody>
+${body}
+</tbody>
+</table>`;
 }
 
 function benchmarkNotes() {
@@ -252,7 +294,7 @@ async function publishSummary(rows) {
     .addHeading("Parser benchmark", 2)
     .addList(notes)
     .addHeading("Comparison", 3)
-    .addRaw(`${benchmarkTable(rows)}\n`);
+    .addRaw(benchmarkHtmlTable(rows), true);
 
   if (fileExists(BASE_OUTPUT)) {
     core.summary
@@ -325,7 +367,7 @@ async function upsertPullRequestComment(rows) {
     "",
     notes,
     "",
-    benchmarkTable(rows),
+    benchmarkMarkdownTable(rows),
     "",
     "_This comment is updated automatically by CI._",
   ].join("\n");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     env:
       RDBINSIGHT_BENCH_PROFILES: "string,list,set,hash,zset,zset2,mixed"
       RDBINSIGHT_BENCH_GENERATED_BYTES: "16777216"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     env:
-      RDBINSIGHT_BENCH_PROFILE: "mixed"
-      RDBINSIGHT_BENCH_GENERATED_BYTES: "67108864"
+      RDBINSIGHT_BENCH_PROFILES: "string,list,set,hash,zset,zset2,mixed"
+      RDBINSIGHT_BENCH_GENERATED_BYTES: "16777216"
       RDBINSIGHT_BENCH_SAMPLE_SIZE: "10"
       RDBINSIGHT_BENCH_WARM_UP_SECS: "1"
       RDBINSIGHT_BENCH_MEASUREMENT_SECS: "1"
@@ -121,6 +122,7 @@ jobs:
       - name: Run parser benchmark
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: node .github/actions/parser-benchmark/index.js
 
       - name: Upload benchmark artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,8 @@ jobs:
           name: parser-benchmark
           path: |
             parser-benchmark-*.txt
-            target/criterion
+            target/criterion-base
+            target/criterion-current
 
   docker-builds:
     name: Docker Build (${{ matrix.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     env:
       RDBINSIGHT_BENCH_PROFILES: "string,list,set,hash,zset,zset2,mixed"
       RDBINSIGHT_BENCH_GENERATED_BYTES: "16777216"
@@ -123,7 +121,6 @@ jobs:
       - name: Run parser benchmark
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          GITHUB_TOKEN: ${{ github.token }}
         run: node .github/actions/parser-benchmark/index.js
 
       - name: Upload benchmark artifacts

--- a/.github/workflows/parser-benchmark-comment.yml
+++ b/.github/workflows/parser-benchmark-comment.yml
@@ -1,0 +1,175 @@
+name: Parser Benchmark Comment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: parser-benchmark-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Parser benchmark comment
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Wait for parser benchmark artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          run_id=""
+          for _ in $(seq 1 60); do
+            run_id="$(gh run list \
+              --repo "$REPO" \
+              --workflow CI \
+              --commit "$HEAD_SHA" \
+              --json databaseId,event,status,conclusion \
+              --jq '[.[] | select(.event == "pull_request") | select(.status == "completed") | select(.conclusion == "success")][0].databaseId // ""')"
+            if [ -n "$run_id" ]; then
+              break
+            fi
+            sleep 20
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "No successful CI run found for $HEAD_SHA; skipping benchmark comment."
+            exit 0
+          fi
+
+          rm -rf /tmp/parser-benchmark-comment
+          mkdir -p /tmp/parser-benchmark-comment
+          if ! gh run download "$run_id" \
+            --repo "$REPO" \
+            --name parser-benchmark \
+            --dir /tmp/parser-benchmark-comment; then
+            echo "No parser-benchmark artifact found on CI run $run_id; skipping benchmark comment."
+            exit 0
+          fi
+
+          node <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
+          const marker = "<!-- rdbinsight-parser-benchmark -->";
+          const root = "/tmp/parser-benchmark-comment/target/criterion";
+
+          function fileExists(filePath) {
+            return fs.existsSync(filePath);
+          }
+
+          function readJson(filePath) {
+            return JSON.parse(fs.readFileSync(filePath, "utf8"));
+          }
+
+          function walkFiles(dir, basename, out = []) {
+            if (!fileExists(dir)) return out;
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const entryPath = path.join(dir, entry.name);
+              if (entry.isDirectory()) {
+                walkFiles(entryPath, basename, out);
+              } else if (entry.name === basename) {
+                out.push(entryPath);
+              }
+            }
+            return out;
+          }
+
+          function benchmarkName(estimatesPath) {
+            return path.relative(root, estimatesPath).split(path.sep).slice(0, -2).join("/");
+          }
+
+          function median(filePath) {
+            return readJson(filePath).median.point_estimate;
+          }
+
+          function bytesFor(name) {
+            const benchmarkPath = path.join(root, ...name.split("/"), "new", "benchmark.json");
+            if (!fileExists(benchmarkPath)) return Number.NaN;
+            return readJson(benchmarkPath).throughput?.Bytes ?? Number.NaN;
+          }
+
+          function duration(ns) {
+            if (!Number.isFinite(ns)) return "-";
+            if (ns < 1_000) return `${ns.toFixed(2)} ns`;
+            if (ns < 1_000_000) return `${(ns / 1_000).toFixed(2)} us`;
+            if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(2)} ms`;
+            return `${(ns / 1_000_000_000).toFixed(2)} s`;
+          }
+
+          function throughput(bytes, ns) {
+            if (!Number.isFinite(bytes) || !Number.isFinite(ns) || ns <= 0) return "-";
+            return `${(bytes / (1024 * 1024) / (ns / 1_000_000_000)).toFixed(2)} MiB/s`;
+          }
+
+          function change(currentNs, baseNs) {
+            if (!Number.isFinite(currentNs) || !Number.isFinite(baseNs) || baseNs <= 0) return "-";
+            const value = (currentNs / baseNs - 1) * 100;
+            const prefix = value > 0 ? "+" : "";
+            const direction = value > 0 ? "slower" : value < 0 ? "faster" : "same";
+            return `${prefix}${value.toFixed(2)}% ${direction}`;
+          }
+
+          const rows = walkFiles(root, "estimates.json")
+            .filter((filePath) => filePath.endsWith(`${path.sep}new${path.sep}estimates.json`))
+            .map((filePath) => {
+              const name = benchmarkName(filePath);
+              const basePath = path.join(path.dirname(path.dirname(filePath)), "base", "estimates.json");
+              const currentNs = median(filePath);
+              const baseNs = fileExists(basePath) ? median(basePath) : Number.NaN;
+              return { name, currentNs, baseNs, bytes: bytesFor(name) };
+            })
+            .sort((a, b) => a.name.localeCompare(b.name));
+
+          const table = rows.length === 0
+            ? "_No Criterion benchmark estimates were found._"
+            : [
+                "| Benchmark | Base median | Current median | Change | Current throughput |",
+                "| --- | ---: | ---: | ---: | ---: |",
+                ...rows.map((row) =>
+                  `| \`${row.name}\` | ${duration(row.baseNs)} | ${duration(row.currentNs)} | ${change(row.currentNs, row.baseNs)} | ${throughput(row.bytes, row.currentNs)} |`
+                ),
+              ].join("\n");
+
+          const body = [
+            marker,
+            "## Parser benchmark",
+            "",
+            "- Base and current benchmarks run in the same CI job on the same GitHub runner.",
+            "- Benchmark excludes disk I/O; RDB bytes are prepared before timing starts.",
+            "- Positive change means the current PR is slower than the base commit.",
+            "",
+            table,
+            "",
+            "_This comment is updated automatically from the benchmark artifact._",
+          ].join("\n");
+
+          fs.writeFileSync("/tmp/parser-benchmark-comment-body.md", body);
+          NODE
+
+          comment_id="$(gh api \
+            "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq '.[] | select(.body | contains("<!-- rdbinsight-parser-benchmark -->")) | .id' \
+            | head -n 1)"
+
+          if [ -n "$comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/$REPO/issues/comments/$comment_id" \
+              --field body=@/tmp/parser-benchmark-comment-body.md >/dev/null
+          else
+            gh api \
+              --method POST \
+              "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --field body=@/tmp/parser-benchmark-comment-body.md >/dev/null
+          fi

--- a/.github/workflows/parser-benchmark-comment.yml
+++ b/.github/workflows/parser-benchmark-comment.yml
@@ -63,7 +63,16 @@ jobs:
           const marker = "<!-- rdbinsight-parser-benchmark -->";
           const baseRoot = "/tmp/parser-benchmark-comment/target/criterion-base";
           const currentRoot = "/tmp/parser-benchmark-comment/target/criterion-current";
-          const benchmarkNamePattern = /^parser\/parse_rdb\/synthetic-(?:(?:string|list|set|hash|zset|zset2)-records|mixed-raw-types)-[1-9][0-9]*MiB$/;
+          const expectedBenchmarkNames = [
+            "parser/parse_rdb/synthetic-hash-records-16MiB",
+            "parser/parse_rdb/synthetic-list-records-16MiB",
+            "parser/parse_rdb/synthetic-mixed-raw-types-16MiB",
+            "parser/parse_rdb/synthetic-set-records-16MiB",
+            "parser/parse_rdb/synthetic-string-records-16MiB",
+            "parser/parse_rdb/synthetic-zset-records-16MiB",
+            "parser/parse_rdb/synthetic-zset2-records-16MiB",
+          ];
+          const expectedBenchmarkNameSet = new Set(expectedBenchmarkNames);
 
           function fileExists(filePath) {
             return fs.existsSync(filePath);
@@ -92,7 +101,7 @@ jobs:
 
           function median(filePath) {
             const value = readJson(filePath).median?.point_estimate;
-            if (!Number.isFinite(value)) {
+            if (!Number.isFinite(value) || value <= 0) {
               throw new Error(`invalid median estimate in ${filePath}`);
             }
             return value;
@@ -142,7 +151,7 @@ jobs:
             .filter((filePath) => filePath.endsWith(`${path.sep}new${path.sep}estimates.json`))
             .flatMap((filePath) => {
               const name = benchmarkName(filePath);
-              if (!benchmarkNamePattern.test(name)) {
+              if (!expectedBenchmarkNameSet.has(name)) {
                 console.log(`Skipping unexpected benchmark name: ${name}`);
                 return [];
               }
@@ -152,6 +161,14 @@ jobs:
               return [{ name, currentNs, baseNs, bytes: bytesFor(name) }];
             })
             .sort((a, b) => a.name.localeCompare(b.name));
+
+          const foundBenchmarkNameSet = new Set(rows.map((row) => row.name));
+          const missingBenchmarkNames = expectedBenchmarkNames.filter(
+            (name) => !foundBenchmarkNameSet.has(name),
+          );
+          if (missingBenchmarkNames.length > 0) {
+            throw new Error(`missing expected benchmark rows: ${missingBenchmarkNames.join(", ")}`);
+          }
 
           const table = rows.length === 0
             ? "_No Criterion benchmark estimates were found._"

--- a/.github/workflows/parser-benchmark-comment.yml
+++ b/.github/workflows/parser-benchmark-comment.yml
@@ -61,7 +61,8 @@ jobs:
           const path = require("node:path");
 
           const marker = "<!-- rdbinsight-parser-benchmark -->";
-          const root = "/tmp/parser-benchmark-comment/target/criterion";
+          const baseRoot = "/tmp/parser-benchmark-comment/target/criterion-base";
+          const currentRoot = "/tmp/parser-benchmark-comment/target/criterion-current";
 
           function fileExists(filePath) {
             return fs.existsSync(filePath);
@@ -85,7 +86,7 @@ jobs:
           }
 
           function benchmarkName(estimatesPath) {
-            return path.relative(root, estimatesPath).split(path.sep).slice(0, -2).join("/");
+            return path.relative(currentRoot, estimatesPath).split(path.sep).slice(0, -2).join("/");
           }
 
           function median(filePath) {
@@ -93,7 +94,7 @@ jobs:
           }
 
           function bytesFor(name) {
-            const benchmarkPath = path.join(root, ...name.split("/"), "new", "benchmark.json");
+            const benchmarkPath = path.join(currentRoot, ...name.split("/"), "new", "benchmark.json");
             if (!fileExists(benchmarkPath)) return Number.NaN;
             return readJson(benchmarkPath).throughput?.Bytes ?? Number.NaN;
           }
@@ -119,11 +120,11 @@ jobs:
             return `${prefix}${value.toFixed(2)}% ${direction}`;
           }
 
-          const rows = walkFiles(root, "estimates.json")
+          const rows = walkFiles(currentRoot, "estimates.json")
             .filter((filePath) => filePath.endsWith(`${path.sep}new${path.sep}estimates.json`))
             .map((filePath) => {
               const name = benchmarkName(filePath);
-              const basePath = path.join(path.dirname(path.dirname(filePath)), "base", "estimates.json");
+              const basePath = path.join(baseRoot, ...name.split("/"), "base", "estimates.json");
               const currentNs = median(filePath);
               const baseNs = fileExists(basePath) ? median(basePath) : Number.NaN;
               return { name, currentNs, baseNs, bytes: bytesFor(name) };

--- a/.github/workflows/parser-benchmark-comment.yml
+++ b/.github/workflows/parser-benchmark-comment.yml
@@ -63,6 +63,7 @@ jobs:
           const marker = "<!-- rdbinsight-parser-benchmark -->";
           const baseRoot = "/tmp/parser-benchmark-comment/target/criterion-base";
           const currentRoot = "/tmp/parser-benchmark-comment/target/criterion-current";
+          const benchmarkNamePattern = /^parser\/parse_rdb\/synthetic-(?:(?:string|list|set|hash|zset|zset2)-records|mixed-raw-types)-[1-9][0-9]*MiB$/;
 
           function fileExists(filePath) {
             return fs.existsSync(filePath);
@@ -90,13 +91,30 @@ jobs:
           }
 
           function median(filePath) {
-            return readJson(filePath).median.point_estimate;
+            const value = readJson(filePath).median?.point_estimate;
+            if (!Number.isFinite(value)) {
+              throw new Error(`invalid median estimate in ${filePath}`);
+            }
+            return value;
           }
 
           function bytesFor(name) {
             const benchmarkPath = path.join(currentRoot, ...name.split("/"), "new", "benchmark.json");
             if (!fileExists(benchmarkPath)) return Number.NaN;
-            return readJson(benchmarkPath).throughput?.Bytes ?? Number.NaN;
+            const value = readJson(benchmarkPath).throughput?.Bytes ?? Number.NaN;
+            return Number.isFinite(value) && value > 0 ? value : Number.NaN;
+          }
+
+          function markdownTableCell(value) {
+            return String(value)
+              .slice(0, 200)
+              .replaceAll("\\", "\\\\")
+              .replaceAll("|", "\\|")
+              .replaceAll("`", "\\`")
+              .replaceAll("\r", " ")
+              .replaceAll("\n", " ")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;");
           }
 
           function duration(ns) {
@@ -122,12 +140,16 @@ jobs:
 
           const rows = walkFiles(currentRoot, "estimates.json")
             .filter((filePath) => filePath.endsWith(`${path.sep}new${path.sep}estimates.json`))
-            .map((filePath) => {
+            .flatMap((filePath) => {
               const name = benchmarkName(filePath);
+              if (!benchmarkNamePattern.test(name)) {
+                console.log(`Skipping unexpected benchmark name: ${name}`);
+                return [];
+              }
               const basePath = path.join(baseRoot, ...name.split("/"), "base", "estimates.json");
               const currentNs = median(filePath);
               const baseNs = fileExists(basePath) ? median(basePath) : Number.NaN;
-              return { name, currentNs, baseNs, bytes: bytesFor(name) };
+              return [{ name, currentNs, baseNs, bytes: bytesFor(name) }];
             })
             .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -137,7 +159,7 @@ jobs:
                 "| Benchmark | Base median | Current median | Change | Current throughput |",
                 "| --- | ---: | ---: | ---: | ---: |",
                 ...rows.map((row) =>
-                  `| \`${row.name}\` | ${duration(row.baseNs)} | ${duration(row.currentNs)} | ${change(row.currentNs, row.baseNs)} | ${throughput(row.bytes, row.currentNs)} |`
+                  `| \`${markdownTableCell(row.name)}\` | ${markdownTableCell(duration(row.baseNs))} | ${markdownTableCell(duration(row.currentNs))} | ${markdownTableCell(change(row.currentNs, row.baseNs))} | ${markdownTableCell(throughput(row.bytes, row.currentNs))} |`
                 ),
               ].join("\n");
 

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -3,9 +3,10 @@ use std::{env, fs, hint::black_box, path::PathBuf, time::Duration};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use rdbinsight::parser::{RDBFileParser, core::buffer::Buffer, error::NeedMoreData};
 
-const DEFAULT_GENERATED_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_GENERATED_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_CHUNK_SIZE: usize = 64 * 1024;
 const DEFAULT_BUFFER_SIZE: usize = 16 * 1024 * 1024;
+const DEFAULT_PROFILES: &[&str] = &["string", "list", "set", "hash", "zset", "zset2", "mixed"];
 
 fn env_usize(name: &str, default: usize) -> usize {
     env::var(name)
@@ -128,6 +129,89 @@ fn synthetic_string_rdb(target_bytes: usize) -> Vec<u8> {
     out
 }
 
+fn synthetic_repeated_rdb<F>(target_bytes: usize, profile: &str, mut push_record: F) -> Vec<u8>
+where F: FnMut(&mut Vec<u8>, &[u8], u64) {
+    let mut out = Vec::with_capacity(target_bytes + 1024);
+    out.extend_from_slice(b"REDIS0011");
+
+    let mut index = 0_u64;
+    while out.len() < target_bytes {
+        let key = format!("bench:{profile}:{index:016}");
+        push_record(&mut out, key.as_bytes(), index);
+        index += 1;
+    }
+
+    out.push(0xff); // EOF.
+    out.extend_from_slice(&0_u64.to_le_bytes()); // Checksum placeholder; parser does not validate it.
+    out
+}
+
+fn synthetic_list_rdb(target_bytes: usize) -> Vec<u8> {
+    let members: [&[u8]; 8] = [
+        b"alpha", b"bravo", b"charlie", b"delta", b"echo", b"foxtrot", b"golf", b"hotel",
+    ];
+    synthetic_repeated_rdb(target_bytes, "list", |out, key, _| {
+        push_list_record(out, key, &members);
+    })
+}
+
+fn synthetic_set_rdb(target_bytes: usize) -> Vec<u8> {
+    let members: [&[u8]; 8] = [
+        b"alpha", b"bravo", b"charlie", b"delta", b"echo", b"foxtrot", b"golf", b"hotel",
+    ];
+    synthetic_repeated_rdb(target_bytes, "set", |out, key, _| {
+        push_set_record(out, key, &members);
+    })
+}
+
+fn synthetic_hash_rdb(target_bytes: usize) -> Vec<u8> {
+    let pairs: [(&[u8], &[u8]); 8] = [
+        (b"name", b"benchmark"),
+        (b"region", b"ci"),
+        (b"owner", b"parser"),
+        (b"state", b"active"),
+        (b"tier", b"hot"),
+        (b"format", b"rdb"),
+        (b"version", b"0011"),
+        (b"profile", b"hash"),
+    ];
+    synthetic_repeated_rdb(target_bytes, "hash", |out, key, _| {
+        push_hash_record(out, key, &pairs);
+    })
+}
+
+fn synthetic_zset_rdb(target_bytes: usize) -> Vec<u8> {
+    let scores: [(&[u8], &[u8]); 8] = [
+        (b"alpha", b"1.25"),
+        (b"bravo", b"2.50"),
+        (b"charlie", b"3.75"),
+        (b"delta", b"4.00"),
+        (b"echo", b"5.25"),
+        (b"foxtrot", b"6.50"),
+        (b"golf", b"7.75"),
+        (b"hotel", b"8.00"),
+    ];
+    synthetic_repeated_rdb(target_bytes, "zset", |out, key, _| {
+        push_zset_record(out, key, &scores);
+    })
+}
+
+fn synthetic_zset2_rdb(target_bytes: usize) -> Vec<u8> {
+    let scores: [(&[u8], f64); 8] = [
+        (b"alpha", 1.25),
+        (b"bravo", 2.50),
+        (b"charlie", 3.75),
+        (b"delta", 4.00),
+        (b"echo", 5.25),
+        (b"foxtrot", 6.50),
+        (b"golf", 7.75),
+        (b"hotel", 8.00),
+    ];
+    synthetic_repeated_rdb(target_bytes, "zset2", |out, key, _| {
+        push_zset2_record(out, key, &scores);
+    })
+}
+
 fn synthetic_mixed_rdb(target_bytes: usize) -> Vec<u8> {
     let mut out = Vec::with_capacity(target_bytes + 1024);
     out.extend_from_slice(b"REDIS0011");
@@ -192,26 +276,48 @@ fn synthetic_mixed_rdb(target_bytes: usize) -> Vec<u8> {
     out
 }
 
-fn generated_benchmark_input(target_bytes: usize) -> (String, Vec<u8>) {
-    let profile = env::var("RDBINSIGHT_BENCH_PROFILE").unwrap_or_else(|_| "mixed".to_owned());
+fn generated_benchmark_input(target_bytes: usize, profile: &str) -> (String, Vec<u8>) {
     let target_mib = target_bytes / 1024 / 1024;
 
-    match profile.as_str() {
+    match profile {
         "string" => (
             format!("synthetic-string-records-{target_mib}MiB"),
             synthetic_string_rdb(target_bytes),
+        ),
+        "list" => (
+            format!("synthetic-list-records-{target_mib}MiB"),
+            synthetic_list_rdb(target_bytes),
+        ),
+        "set" => (
+            format!("synthetic-set-records-{target_mib}MiB"),
+            synthetic_set_rdb(target_bytes),
+        ),
+        "hash" => (
+            format!("synthetic-hash-records-{target_mib}MiB"),
+            synthetic_hash_rdb(target_bytes),
+        ),
+        "zset" => (
+            format!("synthetic-zset-records-{target_mib}MiB"),
+            synthetic_zset_rdb(target_bytes),
+        ),
+        "zset2" => (
+            format!("synthetic-zset2-records-{target_mib}MiB"),
+            synthetic_zset2_rdb(target_bytes),
         ),
         "mixed" => (
             format!("synthetic-mixed-raw-types-{target_mib}MiB"),
             synthetic_mixed_rdb(target_bytes),
         ),
         other => {
-            panic!("unsupported RDBINSIGHT_BENCH_PROFILE {other:?}; expected string or mixed")
+            panic!(
+                "unsupported RDBINSIGHT_BENCH_PROFILE {other:?}; expected one of {}",
+                DEFAULT_PROFILES.join(", ")
+            )
         }
     }
 }
 
-fn benchmark_input() -> (String, Vec<u8>) {
+fn benchmark_inputs() -> Vec<(String, Vec<u8>)> {
     if let Ok(path) = env::var("RDBINSIGHT_BENCH_RDB") {
         let path = PathBuf::from(path);
         let label = path
@@ -221,11 +327,33 @@ fn benchmark_input() -> (String, Vec<u8>) {
             .to_owned();
         let data = fs::read(&path)
             .unwrap_or_else(|err| panic!("failed to read benchmark RDB {}: {err}", path.display()));
-        return (label, data);
+        return vec![(label, data)];
     }
 
     let target_bytes = env_usize("RDBINSIGHT_BENCH_GENERATED_BYTES", DEFAULT_GENERATED_BYTES);
-    generated_benchmark_input(target_bytes)
+    let profiles = env::var("RDBINSIGHT_BENCH_PROFILES")
+        .or_else(|_| env::var("RDBINSIGHT_BENCH_PROFILE"))
+        .ok()
+        .map(|profiles| {
+            profiles
+                .split(',')
+                .map(str::trim)
+                .filter(|profile| !profile.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .filter(|profiles| !profiles.is_empty())
+        .unwrap_or_else(|| {
+            DEFAULT_PROFILES
+                .iter()
+                .map(|profile| (*profile).to_owned())
+                .collect()
+        });
+
+    profiles
+        .iter()
+        .map(|profile| generated_benchmark_input(target_bytes, profile))
+        .collect()
 }
 
 fn parse_rdb(data: &[u8], chunk_size: usize, buffer_size: usize) -> usize {
@@ -271,19 +399,21 @@ fn parse_rdb(data: &[u8], chunk_size: usize, buffer_size: usize) -> usize {
 }
 
 fn bench_parser(c: &mut Criterion) {
-    let (label, data) = benchmark_input();
+    let inputs = benchmark_inputs();
     let chunk_size = env_usize("RDBINSIGHT_BENCH_CHUNK_BYTES", DEFAULT_CHUNK_SIZE);
     let buffer_size = env_usize("RDBINSIGHT_BENCH_BUFFER_BYTES", DEFAULT_BUFFER_SIZE);
 
     let mut group = c.benchmark_group("parser");
-    group.throughput(Throughput::Bytes(data.len() as u64));
-    group.bench_with_input(
-        BenchmarkId::new("parse_rdb", label),
-        &data,
-        |bench, input| {
-            bench.iter(|| parse_rdb(black_box(input), chunk_size, buffer_size));
-        },
-    );
+    for (label, data) in &inputs {
+        group.throughput(Throughput::Bytes(data.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("parse_rdb", label),
+            data,
+            |bench, input| {
+                bench.iter(|| parse_rdb(black_box(input), chunk_size, buffer_size));
+            },
+        );
+    }
     group.finish();
 }
 


### PR DESCRIPTION
## Why
- Parser refactors need a same-run base-vs-head benchmark signal so reviewers can spot broad throughput regressions without comparing results from different runners or time windows.
- The existing parser benchmark only reports one mixed scenario and leaves the comparison buried in raw Criterion output.

## What
- Split the synthetic parser benchmark into `string`, `list`, `set`, `hash`, `zset`, `zset2`, and `mixed` scenarios.
- Preserve separate base and current Criterion outputs, then render median, change, and throughput rows in the job summary.
- Add a `pull_request_target` workflow that upserts a benchmark PR comment for subsequent PRs after this workflow lands on `master`.
- Harden comment generation by accepting only the expected generated benchmark rows, validating numeric estimates, and escaping artifact-derived table content.

Closes #74.
