### PR TITLE
fix(ci): make benchmark comments artifact-driven

### DIFF
--- a/.github/workflows/parser-benchmark-comment.yml
+++ b/.github/workflows/parser-benchmark-comment.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Wait for parser benchmark artifact
         env:
           GH_TOKEN: ${{ github.token }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          COMMENT_RUN_ID: ${{ github.run_id }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
@@ -50,29 +54,26 @@ jobs:
           mkdir -p /tmp/parser-benchmark-comment
           if ! gh run download "$run_id" \
             --repo "$REPO" \
-            --name parser-benchmark \
+            --pattern "parser-benchmark-*" \
             --dir /tmp/parser-benchmark-comment; then
-            echo "No parser-benchmark artifact found on CI run $run_id; skipping benchmark comment."
-            exit 0
+            if ! gh run download "$run_id" \
+              --repo "$REPO" \
+              --name parser-benchmark \
+              --dir /tmp/parser-benchmark-comment; then
+              echo "No parser-benchmark artifact found on CI run $run_id; skipping benchmark comment."
+              exit 0
+            fi
           fi
 
+          export BENCHMARK_RUN_ID="$run_id"
           node <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
 
           const marker = "<!-- rdbinsight-parser-benchmark -->";
-          const baseRoot = "/tmp/parser-benchmark-comment/target/criterion-base";
-          const currentRoot = "/tmp/parser-benchmark-comment/target/criterion-current";
-          const expectedBenchmarkNames = [
-            "parser/parse_rdb/synthetic-hash-records-16MiB",
-            "parser/parse_rdb/synthetic-list-records-16MiB",
-            "parser/parse_rdb/synthetic-mixed-raw-types-16MiB",
-            "parser/parse_rdb/synthetic-set-records-16MiB",
-            "parser/parse_rdb/synthetic-string-records-16MiB",
-            "parser/parse_rdb/synthetic-zset-records-16MiB",
-            "parser/parse_rdb/synthetic-zset2-records-16MiB",
-          ];
-          const expectedBenchmarkNameSet = new Set(expectedBenchmarkNames);
+          const artifactRoot = "/tmp/parser-benchmark-comment";
+          const baseRoots = [];
+          const currentRoots = [];
 
           function fileExists(filePath) {
             return fs.existsSync(filePath);
@@ -95,8 +96,22 @@ jobs:
             return out;
           }
 
-          function benchmarkName(estimatesPath) {
-            return path.relative(currentRoot, estimatesPath).split(path.sep).slice(0, -2).join("/");
+          function collectCriterionRoots(dir) {
+            if (!fileExists(dir)) return;
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+              const entryPath = path.join(dir, entry.name);
+              if (!entry.isDirectory()) continue;
+              if (entryPath.endsWith(`${path.sep}target${path.sep}criterion-base`)) {
+                baseRoots.push(entryPath);
+              } else if (entryPath.endsWith(`${path.sep}target${path.sep}criterion-current`)) {
+                currentRoots.push(entryPath);
+              }
+              collectCriterionRoots(entryPath);
+            }
+          }
+
+          function benchmarkName(root, estimatesPath) {
+            return path.relative(root, estimatesPath).split(path.sep).slice(0, -2).join("/");
           }
 
           function median(filePath) {
@@ -108,8 +123,10 @@ jobs:
           }
 
           function bytesFor(name) {
-            const benchmarkPath = path.join(currentRoot, ...name.split("/"), "new", "benchmark.json");
-            if (!fileExists(benchmarkPath)) return Number.NaN;
+            const benchmarkPath = currentRoots
+              .map((root) => path.join(root, ...name.split("/"), "new", "benchmark.json"))
+              .find(fileExists);
+            if (!benchmarkPath) return Number.NaN;
             const value = readJson(benchmarkPath).throughput?.Bytes ?? Number.NaN;
             return Number.isFinite(value) && value > 0 ? value : Number.NaN;
           }
@@ -147,44 +164,68 @@ jobs:
             return `${prefix}${value.toFixed(2)}% ${direction}`;
           }
 
-          const rows = walkFiles(currentRoot, "estimates.json")
-            .filter((filePath) => filePath.endsWith(`${path.sep}new${path.sep}estimates.json`))
-            .flatMap((filePath) => {
-              const name = benchmarkName(filePath);
-              if (!expectedBenchmarkNameSet.has(name)) {
-                console.log(`Skipping unexpected benchmark name: ${name}`);
-                return [];
-              }
-              const basePath = path.join(baseRoot, ...name.split("/"), "base", "estimates.json");
-              const currentNs = median(filePath);
-              const baseNs = fileExists(basePath) ? median(basePath) : Number.NaN;
-              return [{ name, currentNs, baseNs, bytes: bytesFor(name) }];
-            })
-            .sort((a, b) => a.name.localeCompare(b.name));
-
-          const foundBenchmarkNameSet = new Set(rows.map((row) => row.name));
-          const missingBenchmarkNames = expectedBenchmarkNames.filter(
-            (name) => !foundBenchmarkNameSet.has(name),
-          );
-          if (missingBenchmarkNames.length > 0) {
-            throw new Error(`missing expected benchmark rows: ${missingBenchmarkNames.join(", ")}`);
+          function shortSha(sha) {
+            return (sha || "").slice(0, 7);
           }
 
-          const table = rows.length === 0
-            ? "_No Criterion benchmark estimates were found._"
-            : [
-                "| Benchmark | Base median | Current median | Change | Current throughput |",
-                "| --- | ---: | ---: | ---: | ---: |",
-                ...rows.map((row) =>
-                  `| \`${markdownTableCell(row.name)}\` | ${markdownTableCell(duration(row.baseNs))} | ${markdownTableCell(duration(row.currentNs))} | ${markdownTableCell(change(row.currentNs, row.baseNs))} | ${markdownTableCell(throughput(row.bytes, row.currentNs))} |`
-                ),
-              ].join("\n");
+          function commitLink(repo, sha) {
+            return `[${markdownTableCell(shortSha(sha))}](https://github.com/${repo}/commit/${sha})`;
+          }
+
+          function runLink(label, runId) {
+            return `[${markdownTableCell(label)}](https://github.com/${process.env.REPO}/actions/runs/${runId})`;
+          }
+
+          collectCriterionRoots(artifactRoot);
+          if (currentRoots.length === 0) {
+            throw new Error("no criterion-current directories found in benchmark artifacts");
+          }
+          if (baseRoots.length === 0) {
+            throw new Error("no criterion-base directories found in benchmark artifacts");
+          }
+
+          const rowsByName = new Map();
+          for (const currentRoot of currentRoots) {
+            for (const filePath of walkFiles(currentRoot, "estimates.json")) {
+              if (!filePath.endsWith(`${path.sep}new${path.sep}estimates.json`)) continue;
+
+              const name = benchmarkName(currentRoot, filePath);
+              const basePath = baseRoots
+                .map((baseRoot) => path.join(baseRoot, ...name.split("/"), "base", "estimates.json"))
+                .find(fileExists);
+              if (!basePath) {
+                throw new Error(`missing base benchmark row for ${name}`);
+              }
+
+              rowsByName.set(name, {
+                name,
+                currentNs: median(filePath),
+                baseNs: median(basePath),
+                bytes: bytesFor(name),
+              });
+            }
+          }
+
+          const rows = [...rowsByName.values()].sort((a, b) => a.name.localeCompare(b.name));
+          if (rows.length === 0) {
+            throw new Error("no benchmark rows found in criterion-current artifacts");
+          }
+
+          const table = [
+            "| Benchmark | Base median | Current median | Change | Current throughput |",
+            "| --- | ---: | ---: | ---: | ---: |",
+            ...rows.map((row) =>
+              `| \`${markdownTableCell(row.name)}\` | ${markdownTableCell(duration(row.baseNs))} | ${markdownTableCell(duration(row.currentNs))} | ${markdownTableCell(change(row.currentNs, row.baseNs))} | ${markdownTableCell(throughput(row.bytes, row.currentNs))} |`
+            ),
+          ].join("\n");
 
           const body = [
             marker,
             "## Parser benchmark",
             "",
-            "- Base and current benchmarks run in the same CI job on the same GitHub runner.",
+            "- Each profile's base and current benchmarks run in the same shard job on the same GitHub runner.",
+            `- Base commit: ${commitLink(process.env.BASE_REPO, process.env.BASE_SHA)}; head commit: ${commitLink(process.env.HEAD_REPO, process.env.HEAD_SHA)}.`,
+            `- Benchmark artifacts: ${runLink(`CI run ${process.env.BENCHMARK_RUN_ID}`, process.env.BENCHMARK_RUN_ID)}; comment workflow: ${runLink(`run ${process.env.COMMENT_RUN_ID}`, process.env.COMMENT_RUN_ID)}.`,
             "- Benchmark excludes disk I/O; RDB bytes are prepared before timing starts.",
             "- Positive change means the current PR is slower than the base commit.",
             "",
@@ -194,6 +235,7 @@ jobs:
           ].join("\n");
 
           fs.writeFileSync("/tmp/parser-benchmark-comment-body.md", body);
+          fs.writeFileSync("/tmp/parser-benchmark-comment-row-count.txt", `${rows.length}\n`);
           NODE
 
           comment_id="$(gh api \
@@ -208,8 +250,18 @@ jobs:
               "repos/$REPO/issues/comments/$comment_id" \
               --field body=@/tmp/parser-benchmark-comment-body.md >/dev/null
           else
-            gh api \
+            comment_id="$(gh api \
               --method POST \
               "repos/$REPO/issues/$PR_NUMBER/comments" \
-              --field body=@/tmp/parser-benchmark-comment-body.md >/dev/null
+              --field body=@/tmp/parser-benchmark-comment-body.md \
+              --jq '.id')"
+          fi
+
+          expected_rows="$(cat /tmp/parser-benchmark-comment-row-count.txt)"
+          actual_rows="$(gh api \
+            "repos/$REPO/issues/comments/$comment_id" \
+            --jq '.body | split("\n") | map(select(startswith("| `"))) | length')"
+          if [ "$actual_rows" != "$expected_rows" ]; then
+            echo "Benchmark comment row count mismatch: expected $expected_rows, got $actual_rows"
+            exit 1
           fi


### PR DESCRIPTION
## Why

- `pull_request_target` runs the workflow from the base branch, so benchmark comment fixes inside a feature PR cannot update that same PR's comment behavior.
- Benchmark artifacts may be single-artifact or sharded, and the comment workflow should not need a hard-coded benchmark name list when new cases are added.

## What

- Downloads sharded `parser-benchmark-*` artifacts with a fallback to the legacy `parser-benchmark` artifact.
- Builds the comment table dynamically from Criterion `criterion-current` rows and requires matching `criterion-base` rows for every benchmark.
- Adds base/head commit links, benchmark/comment workflow links, and a post-update row-count check so incomplete PR comments fail the workflow instead of silently posting partial data.
