### PR TITLE
fix(parser): read zipmap large lengths as little-endian

### DIFF
--- a/.github/workflows/publish-test-images.yml
+++ b/.github/workflows/publish-test-images.yml
@@ -7,7 +7,7 @@ on:
       redis_versions:
         description: 'Redis versions to publish as a JSON array, for example: ["8.8.0"]'
         required: false
-        default: '["8.8.0", "8.6.4", "8.0.5", "7.0.15", "6.0.20", "2.8.24"]'
+        default: '["8.8.0", "8.6.4", "8.0.5", "7.0.15", "6.0.20", "2.8.24", "2.4.18"]'
 
 permissions:
   contents: read

--- a/src/parser/record/hash.rs
+++ b/src/parser/record/hash.rs
@@ -6,7 +6,7 @@ use crate::{
     parser::{
         core::{
             buffer::{Buffer, skip_bytes},
-            combinators::{read_be_u32, read_le_u64, read_u8},
+            combinators::{read_le_u32, read_le_u64, read_u8},
             parse::{ParseResult, Parser, ParserInit},
             raw::{RDBStr, read_rdb_len, read_rdb_str},
             view::View,
@@ -293,7 +293,7 @@ fn read_zipmap_size(input: &[u8]) -> AnyResult<(&[u8], Option<u64>)> {
         return Ok((input, Some(flag as u64)));
     }
 
-    let (input, key_len) = read_be_u32(input)?;
+    let (input, key_len) = read_le_u32(input)?;
     Ok((input, Some(key_len as u64)))
 }
 

--- a/tests/common/setup.rs
+++ b/tests/common/setup.rs
@@ -23,6 +23,7 @@ pub enum RedisVariant {
     Redis8_0,
     Redis7_0,
     Redis6_0,
+    Redis2_4,
     Redis2_8,
     StackLatest,
 }
@@ -41,6 +42,7 @@ impl RedisVariant {
             RedisVariant::Redis8_0 => (repo, "8.0.5".to_string()),
             RedisVariant::Redis7_0 => (repo, "7.0.15".to_string()),
             RedisVariant::Redis6_0 => (repo, "6.0.20".to_string()),
+            RedisVariant::Redis2_4 => (repo, "2.4.18".to_string()),
             RedisVariant::Redis2_8 => (repo, "2.8.24".to_string()),
         }
     }
@@ -52,6 +54,7 @@ impl RedisVariant {
             | RedisVariant::Redis8_0
             | RedisVariant::Redis7_0
             | RedisVariant::Redis6_0
+            | RedisVariant::Redis2_4
             | RedisVariant::Redis2_8 => "redis-server",
             RedisVariant::StackLatest => "redis-stack-server",
         }
@@ -167,22 +170,24 @@ impl RedisInstance {
         let (repo, tag) = cfg.variant.image();
         let mut cmd: Vec<String> = Vec::new();
 
-        cmd.push("--appendonly".into());
-        cmd.push("no".into());
-        // Disable protected mode so test instances accept external connections (unsupported on Redis 2.8)
-        if cfg.variant != RedisVariant::Redis2_8 {
-            cmd.push("--protected-mode".into());
+        if cfg.variant != RedisVariant::Redis2_4 {
+            cmd.push("--appendonly".into());
             cmd.push("no".into());
-        }
+            // Disable protected mode so test instances accept external connections.
+            if cfg.variant != RedisVariant::Redis2_8 {
+                cmd.push("--protected-mode".into());
+                cmd.push("no".into());
+            }
 
-        if cfg.diskless {
-            cmd.push("--repl-diskless-sync".into());
-            cmd.push("yes".into());
-            cmd.push("--repl-diskless-sync-delay".into());
-            cmd.push("0".into());
-        } else {
-            cmd.push("--repl-diskless-sync".into());
-            cmd.push("no".into());
+            if cfg.diskless {
+                cmd.push("--repl-diskless-sync".into());
+                cmd.push("yes".into());
+                cmd.push("--repl-diskless-sync-delay".into());
+                cmd.push("0".into());
+            } else {
+                cmd.push("--repl-diskless-sync".into());
+                cmd.push("no".into());
+            }
         }
 
         if !cfg.snapshot {

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -1228,6 +1228,63 @@ async fn hash_zipmap_fixture_lzf_test() -> AnyResult<()> {
 }
 
 #[tokio::test]
+async fn hash_zipmap_large_length_little_endian_test() -> AnyResult<()> {
+    let redis = RedisConfig::default()
+        .with_version(RedisVariant::Redis2_4)
+        .build()
+        .await?;
+
+    let large_field: Vec<u8> = (0..300)
+        .map(|idx| (((idx * 131 + 17) % 251) + 1) as u8)
+        .collect();
+    let rdb_path = redis
+        .generate_rdb("hash_zipmap_large_length_little_endian_test", move |conn| {
+            async move {
+                config_set_many(conn, &[
+                    ("hash-max-zipmap-entries", "1024"),
+                    ("hash-max-zipmap-value", "1024"),
+                ])
+                .await?;
+                redis::cmd("HSET")
+                    .arg("hm_zm_large_len_key")
+                    .arg(large_field)
+                    .arg("v")
+                    .query_async::<()>(conn)
+                    .await?;
+                Ok(())
+            }
+            .boxed()
+        })
+        .await?;
+
+    let dump = tokio::fs::read(&rdb_path).await?;
+    ensure!(
+        dump.windows(5)
+            .any(|window| window == [0xFE, 0x2C, 0x01, 0x00, 0x00]),
+        "expected zipmap large length marker 0xFE followed by little-endian 300"
+    );
+
+    let items = read_filtered_items(&rdb_path).await?;
+
+    assert_eq!(items.len(), 1, "expected exactly one HashRecord");
+    let Item::HashRecord {
+        key,
+        encoding,
+        pair_count,
+        ..
+    } = &items[0]
+    else {
+        panic!("expected HashRecord");
+    };
+
+    assert_eq!(*key, RDBStr::Str(Bytes::from("hm_zm_large_len_key")));
+    assert_eq!(*encoding, HashEncoding::ZipMap);
+    assert_eq!(*pair_count, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn module2_encoding_test() -> AnyResult<()> {
     // Use redis-stack image that ships with official modules; encoding will be Module2 (type id = 7).
     let redis = RedisConfig::default()


### PR DESCRIPTION
## Why
- Zipmap length entries with the `0xFE` large-length marker store the following 4-byte length as little-endian.
- The parser had no integration coverage for that branch, so a big-endian read could regress unnoticed.

## What
- Reads zipmap `0xFE` lengths with `read_le_u32`.
- Adds a Redis 2.4.18-backed integration case that generates a hash zipmap with a 300-byte field and asserts the actual RDB contains the `0xFE` little-endian marker.
- Adds Redis 2.4.18 to the test image variant and publish matrix so CI can run the case.

Fixes #63
